### PR TITLE
Refine TagFilterPanel with checkbox layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "react-scripts": "5.0.1",
     "recharts": "^2.15.3",
     "web-vitals": "^2.1.4",
-    "xlsx": "^0.18.5"
+    "xlsx": "^0.18.5",
+    "jspdf": "^2.5.1",
+    "jspdf-autotable": "^3.5.25"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,14 +7,16 @@ import {
   recommendedFunds as defaultRecommendedFunds,
   assetClassBenchmarks as defaultBenchmarks
 } from './data/config';
-import { 
-  calculateScores, 
-  generateClassSummary, 
+import {
+  calculateScores,
+  generateClassSummary,
   identifyReviewCandidates,
   getScoreColor,
   getScoreLabel,
-  METRICS_CONFIG 
+  METRICS_CONFIG
 } from './services/scoring';
+import { exportToExcel } from './services/exportService';
+import { applyTagRules } from './services/tagEngine';
 import dataStore from './services/dataStore';
 
 // Score badge component for visual display
@@ -230,18 +232,23 @@ const App = () => {
         // Calculate scores for all funds
         console.log('Calculating scores for', withClassAndFlags.length, 'funds...');
         const scoredFunds = calculateScores(withClassAndFlags);
+
+        // Apply automated tagging after scoring
+        const taggedFunds = applyTagRules(scoredFunds, {
+          benchmarks: assetClassBenchmarks
+        });
         
         // Generate class summaries
         const summaries = {};
         const fundsByClass = {};
-        scoredFunds.forEach(fund => {
+        taggedFunds.forEach(fund => {
           const assetClass = fund['Asset Class'];
           if (!fundsByClass[assetClass]) {
             fundsByClass[assetClass] = [];
           }
           fundsByClass[assetClass].push(fund);
         });
-        
+
         Object.entries(fundsByClass).forEach(([assetClass, funds]) => {
           summaries[assetClass] = generateClassSummary(funds);
         });
@@ -249,14 +256,14 @@ const App = () => {
         // Extract benchmark data
         const benchmarks = {};
         Object.entries(assetClassBenchmarks).forEach(([assetClass, { ticker, name }]) => {
-          const match = scoredFunds.find(f => f.cleanSymbol === clean(ticker));
+          const match = taggedFunds.find(f => f.cleanSymbol === clean(ticker));
           if (match) {
             benchmarks[assetClass] = { ...match, name };
           }
         });
 
         // Identify review candidates
-        const reviewCandidates = identifyReviewCandidates(scoredFunds);
+        const reviewCandidates = identifyReviewCandidates(taggedFunds);
 
         // Ask user for snapshot date
         const dateStr = prompt('Enter the date for this snapshot (YYYY-MM-DD):', 
@@ -266,7 +273,7 @@ const App = () => {
           // Save snapshot to IndexedDB
           await dataStore.saveSnapshot({
             date: new Date(dateStr).toISOString(),
-            funds: scoredFunds,
+            funds: taggedFunds,
             classSummaries: summaries,
             reviewCandidates: reviewCandidates,
             fileName: file.name,
@@ -277,11 +284,11 @@ const App = () => {
         }
 
         setFundData(withClassAndFlags);
-        setScoredFundData(scoredFunds);
+        setScoredFundData(taggedFunds);
         setBenchmarkData(benchmarks);
         setClassSummaries(summaries);
-        
-        console.log('Successfully loaded and scored', scoredFunds.length, 'funds');
+
+        console.log('Successfully loaded and scored', taggedFunds.length, 'funds');
       } catch (err) {
         console.error('Error parsing performance file:', err);
         alert('Error parsing file: ' + err.message);
@@ -344,6 +351,12 @@ const App = () => {
     const updated = { ...assetClassBenchmarks };
     updated[className] = { ...updated[className], [field]: value };
     setAssetClassBenchmarks(updated);
+  };
+
+  const handleExport = () => {
+    if (scoredFundData.length === 0) return;
+    const dateStr = new Date().toISOString().split('T')[0];
+    exportToExcel(scoredFundData, `Fund_Export_${dateStr}.xlsx`);
   };
 
   // Get review candidates
@@ -512,11 +525,39 @@ const App = () => {
         <div>
           {scoredFundData.length > 0 ? (
             <div>
-              <div style={{ marginBottom: '1rem' }}>
-                <h2 style={{ fontSize: '1.5rem', fontWeight: 'bold' }}>All Funds with Scores</h2>
-                <p style={{ color: '#6b7280', fontSize: '0.875rem' }}>
-                  Scores calculated using weighted Z-score methodology within each asset class
-                </p>
+              <div
+                style={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'center',
+                  marginBottom: '1rem'
+                }}
+              >
+                <div>
+                  <h2 style={{ fontSize: '1.5rem', fontWeight: 'bold' }}>
+                    All Funds with Scores
+                  </h2>
+                  <p style={{ color: '#6b7280', fontSize: '0.875rem' }}>
+                    Scores calculated using weighted Z-score methodology within each asset class
+                  </p>
+                </div>
+                <button
+                  onClick={handleExport}
+                  style={{
+                    padding: '0.5rem 1rem',
+                    backgroundColor: '#10b981',
+                    color: 'white',
+                    border: 'none',
+                    borderRadius: '0.375rem',
+                    cursor: 'pointer',
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '0.5rem'
+                  }}
+                >
+                  <Download size={16} />
+                  Export to Excel
+                </button>
               </div>
               
               <div style={{ overflowX: 'auto' }}>

--- a/src/components/Dashboard/AssetClassOverview.jsx
+++ b/src/components/Dashboard/AssetClassOverview.jsx
@@ -1,0 +1,149 @@
+import React from 'react';
+import { getScoreColor } from '../../services/scoring';
+import { Layers } from 'lucide-react';
+import TagList from '../TagList.jsx';
+
+/**
+ * Show summary cards for each asset class.
+ * Expects props:
+ *  - funds: array of all loaded fund objects with scores and metrics
+ *  - config: object mapping asset classes to benchmark info { ticker, name }
+ */
+const AssetClassOverview = ({ funds, config }) => {
+  if (!Array.isArray(funds) || funds.length === 0) {
+    return null;
+  }
+
+  const recommended = funds.filter(f => f.isRecommended);
+  if (recommended.length === 0) {
+    return null;
+  }
+
+  const byClass = {};
+  recommended.forEach(f => {
+    const assetClass = f['Asset Class'] || 'Uncategorized';
+    if (!byClass[assetClass]) byClass[assetClass] = [];
+    byClass[assetClass].push(f);
+  });
+
+  const classInfo = Object.entries(byClass).map(([assetClass, classFunds]) => {
+    const count = classFunds.length;
+    const scoreSum = classFunds.reduce((sum, f) => sum + (f.scores?.final || 0), 0);
+    const avgScore = count > 0 ? Math.round(scoreSum / count) : 0;
+
+    // Optional metrics
+    const sharpeValues = classFunds
+      .map(f => f.metrics?.sharpeRatio3Y)
+      .filter(v => v != null && !isNaN(v));
+    const avgSharpe =
+      sharpeValues.length > 0
+        ? (sharpeValues.reduce((s, v) => s + v, 0) / sharpeValues.length).toFixed(2)
+        : null;
+
+    const expenseValues = classFunds
+      .map(f => f.metrics?.expenseRatio)
+      .filter(v => v != null && !isNaN(v));
+    const avgExpense =
+      expenseValues.length > 0
+        ? (expenseValues.reduce((s, v) => s + v, 0) / expenseValues.length).toFixed(2)
+        : null;
+
+    const stdValues = classFunds
+      .map(f => f.metrics?.stdDev3Y)
+      .filter(v => v != null && !isNaN(v));
+    const avgStd =
+      stdValues.length > 0
+        ? (stdValues.reduce((s, v) => s + v, 0) / stdValues.length).toFixed(2)
+        : null;
+
+    const benchmarkTicker = config?.[assetClass]?.ticker || '-';
+    const color = getScoreColor(avgScore);
+    const tags = Array.from(
+      new Set(
+        classFunds.flatMap(f => (Array.isArray(f.tags) ? f.tags : []))
+      )
+    );
+
+    return {
+      assetClass,
+      count,
+      avgScore,
+      avgSharpe,
+      avgExpense,
+      avgStd,
+      benchmarkTicker,
+      color,
+      tags,
+    };
+  });
+
+  return (
+    <div style={{ marginBottom: '1.5rem' }}>
+      <h3
+        style={{
+          fontSize: '1.25rem',
+          fontWeight: 'bold',
+          marginBottom: '0.5rem',
+          display: 'flex',
+          alignItems: 'center',
+          gap: '0.5rem',
+        }}
+      >
+        <Layers size={18} /> Asset Class Overview
+      </h3>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))',
+          gap: '1rem',
+        }}
+      >
+        {classInfo.map(info => (
+          <div
+            key={info.assetClass}
+            style={{
+              border: '1px solid #e5e7eb',
+              borderRadius: '0.5rem',
+              padding: '0.75rem',
+              backgroundColor: `${info.color}10`,
+              display: 'flex',
+              flexDirection: 'column',
+              gap: '0.25rem',
+            }}
+          >
+            <div style={{ fontWeight: 600 }}>{info.assetClass}</div>
+            <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+              <span>Funds: {info.count}</span>
+              <span style={{ color: info.color }}>Avg {info.avgScore}</span>
+            </div>
+            {info.avgSharpe && (
+              <div style={{ fontSize: '0.75rem', color: '#4b5563' }}>
+                Sharpe: {info.avgSharpe}
+              </div>
+            )}
+            {info.avgExpense && (
+              <div style={{ fontSize: '0.75rem', color: '#4b5563' }}>
+                Expense: {info.avgExpense}%
+              </div>
+            )}
+            {info.avgStd && (
+              <div style={{ fontSize: '0.75rem', color: '#4b5563' }}>
+                Std Dev: {info.avgStd}
+              </div>
+            )}
+            <div style={{ fontSize: '0.75rem', color: '#6b7280', marginTop: '0.25rem' }}>
+              Benchmark: {info.benchmarkTicker}
+            </div>
+            {info.tags.length > 0 && (
+              <div style={{ marginTop: '0.25rem' }}>
+                <TagList tags={info.tags} />
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default AssetClassOverview;

--- a/src/components/Dashboard/PerformanceHeatmap.jsx
+++ b/src/components/Dashboard/PerformanceHeatmap.jsx
@@ -1,0 +1,131 @@
+import React from 'react';
+import { getScoreColor } from '../../services/scoring';
+import { LayoutGrid } from 'lucide-react';
+import TagList from '../TagList.jsx';
+
+/**
+ * Render a heatmap of recommended fund scores grouped by asset class.
+ * Expects an array of scored fund objects with fields:
+ *   - Fund Name
+ *   - Symbol
+ *   - Asset Class
+ *   - scores.final
+ *   - tags (optional array of strings)
+ *   - metrics (optional object with expenseRatio, managerTenure)
+ *   - isRecommended
+ *   - isBenchmark
+ */
+const ScoreBadge = ({ score }) => {
+  const color = getScoreColor(score);
+  return (
+    <span
+      style={{
+        backgroundColor: `${color}20`,
+        color,
+        border: `1px solid ${color}50`,
+        borderRadius: '9999px',
+        fontSize: '0.75rem',
+        padding: '0.125rem 0.5rem',
+        display: 'inline-block',
+        minWidth: '2.5rem',
+        textAlign: 'center'
+      }}
+    >
+      {score}
+    </span>
+  );
+};
+
+const FundTile = ({ fund }) => {
+  const color = getScoreColor(fund.scores?.final || 0);
+  const tooltipParts = [];
+  if (fund.metrics?.expenseRatio != null) {
+    tooltipParts.push(`Expense Ratio: ${fund.metrics.expenseRatio}%`);
+  }
+  if (fund.metrics?.managerTenure != null) {
+    tooltipParts.push(`Tenure: ${fund.metrics.managerTenure} yrs`);
+  }
+
+  return (
+    <div
+      title={tooltipParts.join(' | ')}
+      style={{
+        backgroundColor: `${color}20`,
+        border: `1px solid ${color}50`,
+        borderRadius: '0.5rem',
+        padding: '0.5rem',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '0.25rem'
+      }}
+    >
+      <div style={{ fontWeight: 600 }}>{fund['Fund Name']}</div>
+      <div style={{ fontSize: '0.875rem', color: '#374151' }}>{fund.Symbol}</div>
+      <ScoreBadge score={fund.scores?.final || 0} />
+      {Array.isArray(fund.tags) && fund.tags.length > 0 && (
+        <TagList tags={fund.tags} />
+      )}
+    </div>
+  );
+};
+
+const PerformanceHeatmap = ({ funds }) => {
+  if (!Array.isArray(funds) || funds.length === 0) {
+    return null;
+  }
+
+  const filtered = funds.filter(
+    f => f.isRecommended && !f.isBenchmark
+  );
+  if (filtered.length === 0) {
+    return null;
+  }
+
+  const byClass = {};
+  filtered.forEach(f => {
+    const assetClass = f['Asset Class'] || 'Uncategorized';
+    if (!byClass[assetClass]) byClass[assetClass] = [];
+    byClass[assetClass].push(f);
+  });
+
+  Object.values(byClass).forEach(list => {
+    list.sort((a, b) => (b.scores?.final || 0) - (a.scores?.final || 0));
+  });
+
+  return (
+    <div style={{ marginBottom: '1.5rem' }}>
+      <h3
+        style={{
+          fontSize: '1.25rem',
+          fontWeight: 'bold',
+          marginBottom: '0.5rem',
+          display: 'flex',
+          alignItems: 'center',
+          gap: '0.5rem'
+        }}
+      >
+        <LayoutGrid size={18} /> Performance Heatmap
+      </h3>
+
+      {Object.entries(byClass).map(([assetClass, classFunds]) => (
+        <div key={assetClass} style={{ marginBottom: '1rem' }}>
+          <h4 style={{ fontWeight: 'bold', marginBottom: '0.25rem' }}>{assetClass}</h4>
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))',
+              gap: '0.5rem'
+            }}
+          >
+            {classFunds.map(fund => (
+              <FundTile key={fund.Symbol} fund={fund} />
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default PerformanceHeatmap;
+

--- a/src/components/Dashboard/TopBottomPerformers.jsx
+++ b/src/components/Dashboard/TopBottomPerformers.jsx
@@ -1,0 +1,143 @@
+import React from 'react';
+import { getScoreColor, getScoreLabel } from '../../services/scoring';
+import TagList from '../TagList.jsx';
+import { BarChart2 } from 'lucide-react';
+
+/**
+ * Display the top 5 and bottom 5 performing recommended funds.
+ * Expects an array of scored fund objects with fields:
+ *   - Fund Name
+ *   - Symbol
+ *   - Asset Class
+ *   - scores.final
+ *   - tags (array of strings)
+ *   - isBenchmark
+ *   - isRecommended
+ */
+const ScoreBadge = ({ score }) => {
+  const color = getScoreColor(score);
+  const label = getScoreLabel(score);
+  return (
+    <span
+      style={{
+        backgroundColor: `${color}20`,
+        color,
+        border: `1px solid ${color}50`,
+        borderRadius: '9999px',
+        fontSize: '0.75rem',
+        padding: '0.25rem 0.5rem',
+        display: 'inline-block',
+        minWidth: '3rem',
+        textAlign: 'center'
+      }}
+    >
+      {score} - {label}
+    </span>
+  );
+};
+
+const FundRow = ({ fund }) => (
+  <tr style={{ borderBottom: '1px solid #f3f4f6' }}>
+    <td style={{ padding: '0.5rem' }}>{fund['Fund Name']}</td>
+    <td style={{ padding: '0.5rem' }}>{fund.Symbol}</td>
+    <td style={{ padding: '0.5rem' }}>{fund['Asset Class']}</td>
+    <td style={{ padding: '0.5rem', textAlign: 'center' }}>
+      <ScoreBadge score={fund.scores?.final || 0} />
+    </td>
+    <td style={{ padding: '0.5rem' }}>
+      {Array.isArray(fund.tags) && fund.tags.length > 0 ? (
+        <TagList tags={fund.tags} />
+      ) : (
+        <span style={{ color: '#9ca3af' }}>-</span>
+      )}
+    </td>
+    <td style={{ padding: '0.5rem' }}>
+      {fund.isBenchmark && (
+        <span
+          style={{
+            backgroundColor: '#fbbf24',
+            color: '#78350f',
+            padding: '0.125rem 0.5rem',
+            borderRadius: '0.25rem',
+            fontSize: '0.75rem',
+            fontWeight: '500'
+          }}
+        >
+          Benchmark
+        </span>
+      )}
+    </td>
+  </tr>
+);
+
+const TopBottomPerformers = ({ funds }) => {
+  if (!Array.isArray(funds) || funds.length === 0) {
+    return null;
+  }
+
+  const recommended = funds.filter(f => f.isRecommended);
+  if (recommended.length === 0) {
+    return null;
+  }
+
+  const sorted = [...recommended].sort(
+    (a, b) => (b.scores?.final || 0) - (a.scores?.final || 0)
+  );
+  const top = sorted.slice(0, 5);
+  const bottom = sorted.slice(-5).reverse();
+
+  return (
+    <div style={{ marginBottom: '1.5rem' }}>
+      <h3 style={{ fontSize: '1.25rem', fontWeight: 'bold', marginBottom: '0.5rem', display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+        <BarChart2 size={18} /> Top &amp; Bottom Performers
+      </h3>
+
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))', gap: '1rem' }}>
+        <div>
+          <h4 style={{ fontWeight: 'bold', marginBottom: '0.25rem' }}>Top 5</h4>
+          <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+            <thead>
+              <tr style={{ borderBottom: '2px solid #e5e7eb' }}>
+                <th style={{ textAlign: 'left', padding: '0.5rem' }}>Fund</th>
+                <th style={{ textAlign: 'left', padding: '0.5rem' }}>Ticker</th>
+                <th style={{ textAlign: 'left', padding: '0.5rem' }}>Class</th>
+                <th style={{ textAlign: 'center', padding: '0.5rem' }}>Score</th>
+                <th style={{ textAlign: 'left', padding: '0.5rem' }}>Tags</th>
+                <th style={{ padding: '0.5rem' }}></th>
+              </tr>
+            </thead>
+            <tbody>
+              {top.map(fund => (
+                <FundRow key={fund.Symbol} fund={fund} />
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        <div>
+          <h4 style={{ fontWeight: 'bold', marginBottom: '0.25rem' }}>Bottom 5</h4>
+          <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+            <thead>
+              <tr style={{ borderBottom: '2px solid #e5e7eb' }}>
+                <th style={{ textAlign: 'left', padding: '0.5rem' }}>Fund</th>
+                <th style={{ textAlign: 'left', padding: '0.5rem' }}>Ticker</th>
+                <th style={{ textAlign: 'left', padding: '0.5rem' }}>Class</th>
+                <th style={{ textAlign: 'center', padding: '0.5rem' }}>Score</th>
+                <th style={{ textAlign: 'left', padding: '0.5rem' }}>Tags</th>
+                <th style={{ padding: '0.5rem' }}></th>
+              </tr>
+            </thead>
+            <tbody>
+              {bottom.map(fund => (
+                <FundRow key={fund.Symbol} fund={fund} />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TopBottomPerformers;
+

--- a/src/components/Filters/TagFilterPanel.jsx
+++ b/src/components/Filters/TagFilterPanel.jsx
@@ -1,0 +1,61 @@
+import React from 'react';
+
+/**
+ * Vertical panel of tag checkboxes for filtering funds by tag.
+ * @param {Object} props
+ * @param {string[]} props.availableTags - All possible tags to display
+ * @param {string[]} props.selectedTags - Tags currently selected
+ * @param {(tags: string[]) => void} props.onChange - Callback fired with updated tag array
+ */
+const TagFilterPanel = ({ availableTags = [], selectedTags = [], onChange }) => {
+  if (!Array.isArray(availableTags) || availableTags.length === 0) return null;
+
+  const handleToggle = tag => {
+    const active = Array.isArray(selectedTags) && selectedTags.includes(tag);
+    const updated = active
+      ? selectedTags.filter(t => t !== tag)
+      : [...selectedTags, tag];
+
+    if (typeof onChange === 'function') {
+      onChange(updated);
+    }
+  };
+
+  const formatLabel = tag =>
+    tag
+      .replace(/-/g, ' ')
+      .replace(/\b\w/g, c => c.toUpperCase());
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', padding: '0.5rem' }}>
+      {availableTags
+        .slice()
+        .sort((a, b) => a.localeCompare(b))
+        .map(tag => {
+          const checked = Array.isArray(selectedTags) && selectedTags.includes(tag);
+          return (
+            <label
+              key={tag}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                padding: '0.25rem 0',
+                fontWeight: checked ? 600 : 400,
+                color: checked ? '#111827' : '#374151'
+              }}
+            >
+              <input
+                type="checkbox"
+                checked={checked}
+                onChange={() => handleToggle(tag)}
+                style={{ marginRight: '0.5rem' }}
+              />
+              {formatLabel(tag)}
+            </label>
+          );
+        })}
+    </div>
+  );
+};
+
+export default TagFilterPanel;

--- a/src/components/TagList.jsx
+++ b/src/components/TagList.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+
+const TAG_COLORS = {
+  underperformer: '#dc2626',
+  outperformer: '#16a34a',
+  'review-needed': '#eab308'
+};
+
+/**
+ * Render a list of tags as small pill badges.
+ * @param {Array<string>} tags
+ */
+const TagList = ({ tags }) => {
+  if (!Array.isArray(tags) || tags.length === 0) return null;
+  return (
+    <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.25rem' }}>
+      {tags.map(tag => {
+        const color = TAG_COLORS[tag] || '#6b7280';
+        return (
+          <span
+            key={tag}
+            style={{
+              backgroundColor: `${color}20`,
+              color,
+              border: `1px solid ${color}40`,
+              borderRadius: '9999px',
+              fontSize: '0.7rem',
+              padding: '0.125rem 0.5rem'
+            }}
+          >
+            {tag}
+          </span>
+        );
+      })}
+    </div>
+  );
+};
+
+export default TagList;

--- a/src/components/Trends/FundTimeline.jsx
+++ b/src/components/Trends/FundTimeline.jsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import {
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ReferenceLine
+} from 'recharts';
+
+/**
+ * Display a fund's score trend over time.
+ * @param {string} fundSymbol - Fund ticker symbol
+ * @param {Array<Object>} dataSnapshots - Array of monthly snapshot objects
+ */
+const FundTimeline = ({ fundSymbol, dataSnapshots }) => {
+  if (!fundSymbol || !Array.isArray(dataSnapshots) || dataSnapshots.length === 0) {
+    return null;
+  }
+
+  const clean = s => s?.toUpperCase().trim().replace(/[^A-Z0-9]/g, '');
+  const target = clean(fundSymbol);
+
+  const sorted = [...dataSnapshots].sort((a, b) => new Date(a.date) - new Date(b.date));
+
+  const chartData = sorted.map(snapshot => {
+    const fund = snapshot.funds.find(f => (f.cleanSymbol || clean(f.Symbol)) === target);
+    const assetClass = fund?.['Asset Class'];
+    let benchmarkScore = null;
+    if (assetClass) {
+      const benchmark = snapshot.funds.find(
+        f => f.isBenchmark && f['Asset Class'] === assetClass
+      );
+      if (benchmark) benchmarkScore = benchmark.scores?.final ?? null;
+    }
+
+    return {
+      date: new Date(snapshot.date).toLocaleDateString('en-US', { month: 'short', year: '2-digit' }),
+      score: fund?.scores?.final ?? null,
+      benchmark: benchmarkScore
+    };
+  }).filter(d => d.score != null);
+
+  if (chartData.length === 0) {
+    return <p>No history available for {fundSymbol}</p>;
+  }
+
+  return (
+    <div style={{ border: '1px solid #e5e7eb', borderRadius: '0.5rem', padding: '1rem', backgroundColor: '#fff' }}>
+      <h3 style={{ fontSize: '1.25rem', fontWeight: 'bold', marginBottom: '0.5rem' }}>
+        Score Trend: {fundSymbol.toUpperCase()}
+      </h3>
+      <ResponsiveContainer width="100%" height={300}>
+        <LineChart data={chartData} margin={{ top: 5, right: 20, bottom: 5, left: 0 }}>
+          <CartesianGrid stroke="#f3f4f6" strokeDasharray="3 3" />
+          <XAxis dataKey="date" />
+          <YAxis domain={[0, 100]} />
+          <Tooltip />
+          <Legend />
+          <ReferenceLine y={70} stroke="#16a34a" strokeDasharray="3 3" />
+          <ReferenceLine y={50} stroke="#eab308" strokeDasharray="3 3" />
+          <Line type="monotone" dataKey="score" name="Score" stroke="#2563eb" dot={{ r: 3 }} />
+          {chartData.some(d => d.benchmark != null) && (
+            <Line type="monotone" dataKey="benchmark" name="Benchmark" stroke="#6b7280" strokeDasharray="4 4" dot={{ r: 3 }} />
+          )}
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+};
+
+export default FundTimeline;

--- a/src/services/exportService.js
+++ b/src/services/exportService.js
@@ -1,0 +1,84 @@
+// src/services/exportService.js
+
+import * as XLSX from 'xlsx';
+import jsPDF from 'jspdf';
+import 'jspdf-autotable';
+
+/**
+ * Export an array of fund objects to an Excel (.xlsx) file.
+ * @param {Array<Object>} funds - Scored and tagged fund objects
+ * @param {string} [filename] - Optional filename for download
+ */
+export function exportToExcel(funds, filename) {
+  if (!Array.isArray(funds) || funds.length === 0) return;
+
+  const dateStr = new Date().toISOString().split('T')[0];
+  const safeName = filename || `Fund_Export_${dateStr}.xlsx`;
+
+  const rows = funds.map(fund => ({
+    Symbol: fund.cleanSymbol || fund.Symbol || fund.symbol || '',
+    'Fund Name': fund['Fund Name'] || fund.name || '',
+    'Asset Class': fund['Asset Class'] || fund.assetClass || '',
+    Score: fund.scores?.final ?? '',
+    Tags: Array.isArray(fund.tags) ? fund.tags.join(', ') : '',
+    'Expense Ratio': fund.metrics?.expenseRatio ?? '',
+    'Sharpe Ratio': fund.metrics?.sharpeRatio3Y ?? '',
+    'Std Dev':
+      fund.metrics?.stdDev5Y ?? fund.metrics?.stdDev3Y ?? '',
+    Alpha: fund.metrics?.alpha5Y ?? '',
+    'Up Capture': fund.metrics?.upCapture3Y ?? '',
+    'Down Capture': fund.metrics?.downCapture3Y ?? '',
+    'Manager Tenure':
+      fund.metrics?.managerTenure ?? fund.managerTenure ?? ''
+  }));
+
+  const worksheet = XLSX.utils.json_to_sheet(rows);
+  const workbook = XLSX.utils.book_new();
+  XLSX.utils.book_append_sheet(workbook, worksheet, 'Funds');
+
+  XLSX.writeFile(workbook, safeName);
+}
+
+/**
+ * Export recommended funds to a PDF summary.
+ * @param {Array<Object>} funds - Scored and tagged fund objects
+ * @param {string} [filename] - Optional filename for download
+ */
+export function exportToPDF(funds, filename) {
+  if (!Array.isArray(funds) || funds.length === 0) return;
+
+  const dateStr = new Date().toISOString().split('T')[0];
+  const safeName = filename || `Fund_Summary_${dateStr}.pdf`;
+
+  const doc = new jsPDF();
+
+  // Header
+  doc.setFontSize(16);
+  doc.text('Fund Performance Summary', 14, 20);
+  doc.setFontSize(10);
+  const dateOptions = { year: 'numeric', month: 'long', day: 'numeric' };
+  doc.text(new Date().toLocaleDateString(undefined, dateOptions), 14, 28);
+
+  // Recommended funds only
+  const rows = funds
+    .filter(f => f.isRecommended)
+    .map(f => [
+      f.cleanSymbol || f.Symbol || f.symbol || '',
+      f['Fund Name'] || f.name || '',
+      f['Asset Class'] || f.assetClass || '',
+      f.scores?.final != null ? String(f.scores.final) : '',
+      Array.isArray(f.tags) ? f.tags.join(', ') : '',
+      f.isBenchmark ? 'Yes' : ''
+    ]);
+
+  doc.autoTable({
+    head: [['Symbol', 'Fund Name', 'Asset Class', 'Score', 'Tags', 'Benchmark?']],
+    body: rows,
+    startY: 34,
+    styles: { fontSize: 8 },
+    theme: 'grid',
+    headStyles: { fillColor: [230, 230, 230] }
+  });
+
+  doc.save(safeName);
+}

--- a/src/services/scoring.js
+++ b/src/services/scoring.js
@@ -428,22 +428,22 @@ const METRIC_WEIGHTS = {
    * @param {number} score - Score value (0-100)
    * @returns {string} Color hex code
    */
-  export function getScoreColor(score) {
-    if (score >= 70) return '#16a34a'; // Green
-    if (score >= 50) return '#eab308'; // Yellow
-    return '#dc2626'; // Red
-  }
+export function getScoreColor(score) {
+  if (score >= 70) return '#16a34a'; // Green
+  if (score >= 50) return '#eab308'; // Yellow
+  return '#dc2626'; // Red
+}
   
   /**
    * Get score label based on value
    * @param {number} score - Score value (0-100)
    * @returns {string} Performance label
    */
-  export function getScoreLabel(score) {
-    if (score >= 70) return 'Excellent';
-    if (score >= 50) return 'Good';
-    return 'Poor';
-  }
+export function getScoreLabel(score) {
+  if (score >= 70) return 'Strong';
+  if (score >= 50) return 'Average';
+  return 'Weak';
+}
   
   // Export all metric information for UI use
   export const METRICS_CONFIG = {

--- a/src/services/tagEngine.js
+++ b/src/services/tagEngine.js
@@ -1,0 +1,92 @@
+// src/services/tagEngine.js
+
+/**
+ * Apply automatic tagging rules to scored funds.
+ * @param {Array<Object>} funds - Array of fund objects with metrics and scores.
+ * @param {Object} config - App configuration (may contain benchmark info).
+ * @returns {Array<Object>} New array of funds with updated `tags` arrays.
+ */
+export function applyTagRules(funds, config = {}) {
+  if (!Array.isArray(funds)) return [];
+
+  const expenseAvgByClass = {};
+  const stdAvgByClass = {};
+
+  funds.forEach(fund => {
+    const assetClass = fund['Asset Class'] || fund.assetClass || 'Unknown';
+    if (!expenseAvgByClass[assetClass]) expenseAvgByClass[assetClass] = [];
+    if (!stdAvgByClass[assetClass]) stdAvgByClass[assetClass] = [];
+
+    const er = fund.metrics?.expenseRatio;
+    if (er != null && !isNaN(er)) expenseAvgByClass[assetClass].push(er);
+
+    const sd = fund.metrics?.stdDev5Y;
+    if (sd != null && !isNaN(sd)) stdAvgByClass[assetClass].push(sd);
+  });
+
+  Object.keys(expenseAvgByClass).forEach(ac => {
+    const vals = expenseAvgByClass[ac];
+    expenseAvgByClass[ac] =
+      vals.length > 0 ? vals.reduce((s, v) => s + v, 0) / vals.length : null;
+  });
+
+  Object.keys(stdAvgByClass).forEach(ac => {
+    const vals = stdAvgByClass[ac];
+    stdAvgByClass[ac] =
+      vals.length > 0 ? vals.reduce((s, v) => s + v, 0) / vals.length : null;
+  });
+
+  const benchmarkSharpe = {};
+  funds.forEach(fund => {
+    if (fund.isBenchmark) {
+      const assetClass = fund['Asset Class'] || fund.assetClass || 'Unknown';
+      const sharpe = fund.metrics?.sharpeRatio3Y;
+      if (sharpe != null && !isNaN(sharpe)) {
+        benchmarkSharpe[assetClass] = sharpe;
+      }
+    }
+  });
+
+  return funds.map(fund => {
+    const assetClass = fund['Asset Class'] || fund.assetClass || 'Unknown';
+    const tags = new Set(Array.isArray(fund.tags) ? fund.tags : []);
+
+    const score = fund.scores?.final;
+    if (typeof score === 'number') {
+      if (score < 40) tags.add('underperformer');
+      if (score >= 70) tags.add('outperformer');
+    }
+
+    const expense = fund.metrics?.expenseRatio;
+    const classAvgExpense = expenseAvgByClass[assetClass];
+    if (
+      expense != null &&
+      classAvgExpense != null &&
+      expense > classAvgExpense * 1.5
+    ) {
+      tags.add('expensive');
+    }
+
+    const stdDev = fund.metrics?.stdDev5Y;
+    const classAvgStd = stdAvgByClass[assetClass];
+    if (
+      stdDev != null &&
+      classAvgStd != null &&
+      stdDev > classAvgStd * 1.2
+    ) {
+      tags.add('high-risk');
+    }
+
+    const sharpe = fund.metrics?.sharpeRatio3Y;
+    const benchSharpe = benchmarkSharpe[assetClass];
+    if (
+      sharpe != null &&
+      benchSharpe != null &&
+      sharpe < benchSharpe * 0.8
+    ) {
+      tags.add('review-needed');
+    }
+
+    return { ...fund, tags: Array.from(tags) };
+  });
+}


### PR DESCRIPTION
## Summary
- redo `TagFilterPanel` to render checkboxes in a vertical panel

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68544816c97883299bcda803e336ff80