### PR TITLE
Update export button location and Excel export

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,6 @@
 // App.jsx
 import React, { useState, useEffect, useContext } from 'react';
-import { Upload, RefreshCw, Settings, Plus, Trash2, LayoutGrid, AlertCircle, TrendingUp, Award, Clock, Database, Calendar, Download, ArrowUpDown } from 'lucide-react';
+import { Upload, RefreshCw, Settings, Plus, Trash2, LayoutGrid, AlertCircle, TrendingUp, Award, Clock, Database, Calendar, ArrowUpDown } from 'lucide-react';
 import * as XLSX from 'xlsx';
 import { getStoredConfig, saveStoredConfig } from './data/storage';
 import {
@@ -15,7 +15,6 @@ import {
   getScoreLabel,
   METRICS_CONFIG
 } from './services/scoring';
-import { exportToExcel } from './services/exportService';
 import { applyTagRules } from './services/tagEngine';
 import dataStore from './services/dataStore';
 import FundView from './components/Views/FundView.jsx';
@@ -368,11 +367,6 @@ const App = () => {
     setAssetClassBenchmarks(updated);
   };
 
-  const handleExport = () => {
-    if (scoredFundData.length === 0) return;
-    const dateStr = new Date().toISOString().split('T')[0];
-    exportToExcel(scoredFundData, `Fund_Export_${dateStr}.xlsx`);
-  };
 
   // Get review candidates
   const reviewCandidates = identifyReviewCandidates(scoredFundData);
@@ -559,23 +553,6 @@ const App = () => {
                 </p>
               </div>
 
-              <button
-                onClick={handleExport}
-                style={{
-                  padding: '0.5rem 1rem',
-                  backgroundColor: '#10b981',
-                  color: 'white',
-                  border: 'none',
-                  borderRadius: '0.375rem',
-                  cursor: 'pointer',
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: '0.5rem'
-                }}
-              >
-                <Download size={16} />
-                Export to Excel
-              </button>
             </div>
 
             {/* Main table */}
@@ -672,16 +649,6 @@ const App = () => {
           <p style={{ color: '#6b7280' }}>No scored funds to display.</p>
         )}
       </div>
-
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: '0.5rem'
-                }}
-              >
-                <Download size={16} />
-                Export to Excel
-              </button>
-            </div>
             <FundView />
           </div>
         ) : (

--- a/src/components/Views/FundView.jsx
+++ b/src/components/Views/FundView.jsx
@@ -1,6 +1,8 @@
 import React, { useContext } from 'react';
 import GlobalFilterBar from '../Filters/GlobalFilterBar.jsx';
 import TagList from '../TagList.jsx';
+import { Download } from 'lucide-react';
+import { exportToExcel } from '../../services/exportService';
 import { getScoreColor, getScoreLabel } from '../../services/scoring';
 import AppContext from '../../context/AppContext.jsx';
 
@@ -78,6 +80,11 @@ const FundView = () => {
     return classMatch && tagMatch;
   });
 
+  const handleExport = () => {
+    if (filteredFunds.length === 0) return;
+    exportToExcel(filteredFunds);
+  };
+
   return (
     <div>
       <GlobalFilterBar
@@ -89,8 +96,31 @@ const FundView = () => {
         onTagToggle={toggleTag}
         onReset={resetFilters}
       />
+      <div style={{ marginBottom: '1rem' }}>
+        <button
+          onClick={handleExport}
+          style={{
+            padding: '0.5rem 1rem',
+            backgroundColor: '#10b981',
+            color: 'white',
+            border: 'none',
+            borderRadius: '0.375rem',
+            cursor: 'pointer',
+            display: 'flex',
+            alignItems: 'center',
+            gap: '0.5rem'
+          }}
+        >
+          <Download size={16} />
+          Export to Excel
+        </button>
+      </div>
 
-      <FundTable funds={filteredFunds} />
+      {filteredFunds.length === 0 ? (
+        <p style={{ color: '#6b7280' }}>No funds match your current filter selection.</p>
+      ) : (
+        <FundTable funds={filteredFunds} />
+      )}
     </div>
   );
 };

--- a/src/services/exportService.js
+++ b/src/services/exportService.js
@@ -6,16 +6,16 @@ import 'jspdf-autotable';
 
 /**
  * Export an array of fund objects to an Excel (.xlsx) file.
- * @param {Array<Object>} funds - Scored and tagged fund objects
+ * @param {Array<Object>} filteredFunds - Scored and tagged fund objects
  * @param {string} [filename] - Optional filename for download
  */
-export function exportToExcel(funds, filename) {
-  if (!Array.isArray(funds) || funds.length === 0) return;
+export function exportToExcel(filteredFunds, filename) {
+  if (!Array.isArray(filteredFunds) || filteredFunds.length === 0) return;
 
   const dateStr = new Date().toISOString().split('T')[0];
   const safeName = filename || `Fund_Export_${dateStr}.xlsx`;
 
-  const rows = funds.map(fund => ({
+  const rows = filteredFunds.map(fund => ({
     Symbol: fund.cleanSymbol || fund.Symbol || fund.symbol || '',
     'Fund Name': fund['Fund Name'] || fund.name || '',
     'Asset Class': fund['Asset Class'] || fund.assetClass || '',


### PR DESCRIPTION
## Summary
- rename `exportToExcel` param to `filteredFunds`
- move export button into FundView and call with filtered data
- remove obsolete export logic from `App.jsx`

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68548199a2f48329b46544101f4e3031