### PR TITLE
Add history snapshot persistence

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,6 @@
 // App.jsx
 import React, { useState, useEffect, useContext } from 'react';
-import { Upload, RefreshCw, Settings, Plus, Trash2, LayoutGrid, AlertCircle, TrendingUp, Award, Clock, Database, Calendar, Download, ArrowUpDown } from 'lucide-react';
+import { Upload, RefreshCw, Settings, Plus, Trash2, LayoutGrid, AlertCircle, TrendingUp, Award, Clock, Database, Calendar, ArrowUpDown } from 'lucide-react';
 import * as XLSX from 'xlsx';
 import { getStoredConfig, saveStoredConfig } from './data/storage';
 import {
@@ -15,10 +15,10 @@ import {
   getScoreLabel,
   METRICS_CONFIG
 } from './services/scoring';
-import { exportToExcel } from './services/exportService';
 import { applyTagRules } from './services/tagEngine';
 import dataStore from './services/dataStore';
 import FundView from './components/Views/FundView.jsx';
+import DashboardView from './components/Views/DashboardView.jsx';
 import AppContext from './context/AppContext.jsx';
 
 // Score badge component for visual display
@@ -75,13 +75,17 @@ const App = () => {
   const {
     fundData,
     setFundData,
+    config,
+    setConfig,
     selectedClass,
     setSelectedClass,
     selectedTags,
     toggleTag,
     resetFilters,
     availableClasses,
-    availableTags
+    availableTags,
+    historySnapshots,
+    setHistorySnapshots,
   } = useContext(AppContext);
 
   const [scoredFundData, setScoredFundData] = useState([]);
@@ -102,6 +106,19 @@ const App = () => {
   const [recommendedFunds, setRecommendedFunds] = useState([]);
   const [assetClassBenchmarks, setAssetClassBenchmarks] = useState({});
 
+  // Load history snapshots from localStorage on startup
+  useEffect(() => {
+    const stored = JSON.parse(localStorage.getItem('ls_history') || '[]');
+    if (stored.length > 0) {
+      setHistorySnapshots(stored);
+    }
+  }, []);
+
+  // Persist history snapshots to localStorage whenever they change
+  useEffect(() => {
+    localStorage.setItem('ls_history', JSON.stringify(historySnapshots));
+  }, [historySnapshots]);
+
   // Initialize configuration
   useEffect(() => {
     const initializeConfig = async () => {
@@ -110,6 +127,7 @@ const App = () => {
       const initializedBenchmarks = savedBenchmarks || defaultBenchmarks;
       setRecommendedFunds(initializedFunds);
       setAssetClassBenchmarks(initializedBenchmarks);
+      setConfig(initializedBenchmarks);
       await saveStoredConfig(initializedFunds, initializedBenchmarks);
     };
     
@@ -120,6 +138,7 @@ const App = () => {
   useEffect(() => {
     if (recommendedFunds.length > 0 || Object.keys(assetClassBenchmarks).length > 0) {
       saveStoredConfig(recommendedFunds, assetClassBenchmarks);
+      setConfig(assetClassBenchmarks);
     }
   }, [recommendedFunds, assetClassBenchmarks]);
 
@@ -295,6 +314,14 @@ const App = () => {
           setCurrentSnapshotDate(dateStr);
         }
 
+        const today = new Date().toISOString().slice(0, 10);
+        const newSnap = { date: today, funds: taggedFunds };
+
+        setHistorySnapshots(prev => {
+          const filtered = prev.filter(s => s.date !== today);
+          return [...filtered, newSnap].slice(-24);
+        });
+
         // after all fund-mapping transforms are finished …
         setFundData(taggedFunds);
 
@@ -366,13 +393,9 @@ const App = () => {
     const updated = { ...assetClassBenchmarks };
     updated[className] = { ...updated[className], [field]: value };
     setAssetClassBenchmarks(updated);
+    setConfig(updated);
   };
 
-  const handleExport = () => {
-    if (scoredFundData.length === 0) return;
-    const dateStr = new Date().toISOString().split('T')[0];
-    exportToExcel(scoredFundData, `Fund_Export_${dateStr}.xlsx`);
-  };
 
   // Get review candidates
   const reviewCandidates = identifyReviewCandidates(scoredFundData);
@@ -389,8 +412,8 @@ const App = () => {
       </div>
 
       <div style={{ marginBottom: '1rem', display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
-        <button 
-          onClick={() => setActiveTab('funds')} 
+        <button
+          onClick={() => setActiveTab('funds')}
           style={{ 
             padding: '0.5rem 1rem',
             backgroundColor: activeTab === 'funds' ? '#3b82f6' : '#e5e7eb',
@@ -405,6 +428,24 @@ const App = () => {
         >
           <Award size={16} />
           Fund Scores
+        </button>
+
+        <button
+          onClick={() => setActiveTab('dashboard')}
+          style={{
+            padding: '0.5rem 1rem',
+            backgroundColor: activeTab === 'dashboard' ? '#3b82f6' : '#e5e7eb',
+            color: activeTab === 'dashboard' ? 'white' : '#374151',
+            border: 'none',
+            borderRadius: '0.375rem',
+            cursor: 'pointer',
+            display: 'flex',
+            alignItems: 'center',
+            gap: '0.5rem'
+          }}
+        >
+          <Database size={16} />
+          Dashboard
         </button>
         
         <button 
@@ -535,6 +576,11 @@ const App = () => {
         </div>
       )}
 
+      {/* Dashboard Tab */}
+      {activeTab === 'dashboard' && (
+        <DashboardView />
+      )}
+
       {/* Fund Scores Tab */}
       {activeTab === 'funds' && (
       <div>
@@ -559,23 +605,6 @@ const App = () => {
                 </p>
               </div>
 
-              <button
-                onClick={handleExport}
-                style={{
-                  padding: '0.5rem 1rem',
-                  backgroundColor: '#10b981',
-                  color: 'white',
-                  border: 'none',
-                  borderRadius: '0.375rem',
-                  cursor: 'pointer',
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: '0.5rem'
-                }}
-              >
-                <Download size={16} />
-                Export to Excel
-              </button>
             </div>
 
             {/* Main table */}
@@ -672,16 +701,6 @@ const App = () => {
           <p style={{ color: '#6b7280' }}>No scored funds to display.</p>
         )}
       </div>
-
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: '0.5rem'
-                }}
-              >
-                <Download size={16} />
-                Export to Excel
-              </button>
-            </div>
             <FundView />
           </div>
         ) : (
@@ -1344,7 +1363,11 @@ const App = () => {
                   ...assetClassBenchmarks,
                   [newClass]: { ticker: '', name: '' }
                 });
-              }} 
+                setConfig({
+                  ...assetClassBenchmarks,
+                  [newClass]: { ticker: '', name: '' }
+                });
+              }}
               style={{ 
                 marginBottom: '0.5rem',
                 padding: '0.5rem 1rem',
@@ -1403,6 +1426,7 @@ const App = () => {
                           const copy = { ...assetClassBenchmarks };
                           delete copy[className];
                           setAssetClassBenchmarks(copy);
+                          setConfig(copy);
                         }}
                         style={{
                           padding: '0.25rem',

--- a/src/components/Dashboard/AssetClassOverview.jsx
+++ b/src/components/Dashboard/AssetClassOverview.jsx
@@ -1,7 +1,9 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { getScoreColor } from '../../services/scoring';
 import { Layers } from 'lucide-react';
 import TagList from '../TagList.jsx';
+import { LineChart, Line } from 'recharts';
+import AppContext from '../../context/AppContext.jsx';
 
 /**
  * Show summary cards for each asset class.
@@ -9,7 +11,28 @@ import TagList from '../TagList.jsx';
  *  - config  : object mapping asset classes to benchmark info { ticker, name }
  */
 const AssetClassOverview = ({ funds, config }) => {
-  if (!Array.isArray(funds) || funds.length === 0) return null;
+  const { historySnapshots } = useContext(AppContext);
+  if (!Array.isArray(funds) || funds.length === 0) {
+    return <p style={{ color: '#6b7280' }}>No data loaded yet.</p>;
+  }
+
+  const getTrendData = (assetClass) => {
+    return historySnapshots
+      .slice(-6)
+      .map((snap) => {
+        const rec = snap.funds.filter(
+          (f) => f.isRecommended && f['Asset Class'] === assetClass
+        );
+        const avg = rec.length
+          ? Math.round(
+              rec.reduce((sum, f) => sum + (f.scores?.final || 0), 0) /
+                rec.length
+            )
+          : null;
+        return { date: snap.date, value: avg };
+      })
+      .filter((d) => d.value !== null);
+  };
 
   const recommended = funds.filter(f => f.isRecommended);
   if (recommended.length === 0) return null;
@@ -43,6 +66,8 @@ const AssetClassOverview = ({ funds, config }) => {
       new Set(classFunds.flatMap(f => (Array.isArray(f.tags) ? f.tags : [])))
     );
 
+    const trend = getTrendData(assetClass);
+
     return {
       assetClass,
       count,
@@ -52,7 +77,8 @@ const AssetClassOverview = ({ funds, config }) => {
       avgStd,
       benchmarkTicker,
       color,
-      tags
+      tags,
+      trend
     };
   });
 
@@ -94,9 +120,22 @@ const AssetClassOverview = ({ funds, config }) => {
           >
             <div style={{ fontWeight: 600 }}>{info.assetClass}</div>
 
-            <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+            <div
+              style={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'center'
+              }}
+            >
               <span>Funds: {info.count}</span>
-              <span style={{ color: info.color }}>Avg {info.avgScore}</span>
+              <div style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
+                <span style={{ color: info.color }}>Avg {info.avgScore}</span>
+                {info.trend && info.trend.length > 0 && (
+                  <LineChart width={120} height={30} data={info.trend}>
+                    <Line type="monotone" dataKey="value" stroke={info.color} dot={false} />
+                  </LineChart>
+                )}
+              </div>
             </div>
 
             {info.avgSharpe && (

--- a/src/components/Views/DashboardView.jsx
+++ b/src/components/Views/DashboardView.jsx
@@ -1,0 +1,19 @@
+import React, { useContext } from 'react';
+import AssetClassOverview from '../Dashboard/AssetClassOverview.jsx';
+import AppContext from '../../context/AppContext.jsx';
+
+const DashboardView = () => {
+  const { fundData, config } = useContext(AppContext);
+
+  return (
+    <div style={{ padding: '1rem' }}>
+      <h2 style={{ fontSize: '1.5rem', fontWeight: 600, marginBottom: '1rem' }}>
+        Dashboard Overview
+      </h2>
+
+      <AssetClassOverview funds={fundData} config={config} />
+    </div>
+  );
+};
+
+export default DashboardView;

--- a/src/components/Views/FundView.jsx
+++ b/src/components/Views/FundView.jsx
@@ -1,6 +1,8 @@
 import React, { useContext } from 'react';
 import GlobalFilterBar from '../Filters/GlobalFilterBar.jsx';
 import TagList from '../TagList.jsx';
+import { Download } from 'lucide-react';
+import { exportToExcel } from '../../services/exportService';
 import { getScoreColor, getScoreLabel } from '../../services/scoring';
 import AppContext from '../../context/AppContext.jsx';
 
@@ -78,6 +80,11 @@ const FundView = () => {
     return classMatch && tagMatch;
   });
 
+  const handleExport = () => {
+    if (filteredFunds.length === 0) return;
+    exportToExcel(filteredFunds);
+  };
+
   return (
     <div>
       <GlobalFilterBar
@@ -89,8 +96,31 @@ const FundView = () => {
         onTagToggle={toggleTag}
         onReset={resetFilters}
       />
+      <div style={{ marginBottom: '1rem' }}>
+        <button
+          onClick={handleExport}
+          style={{
+            padding: '0.5rem 1rem',
+            backgroundColor: '#10b981',
+            color: 'white',
+            border: 'none',
+            borderRadius: '0.375rem',
+            cursor: 'pointer',
+            display: 'flex',
+            alignItems: 'center',
+            gap: '0.5rem'
+          }}
+        >
+          <Download size={16} />
+          Export to Excel
+        </button>
+      </div>
 
-      <FundTable funds={filteredFunds} />
+      {filteredFunds.length === 0 ? (
+        <p style={{ color: '#6b7280' }}>No funds match your current filter selection.</p>
+      ) : (
+        <FundTable funds={filteredFunds} />
+      )}
     </div>
   );
 };

--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -1,4 +1,5 @@
 import React, { createContext, useState, useMemo } from 'react';
+import { assetClassBenchmarks as defaultBenchmarks } from '../data/config';
 
 const AppContext = createContext();
 
@@ -6,6 +7,8 @@ export const AppProvider = ({ children }) => {
   const [fundData, setFundData] = useState([]);
   const [selectedClass, setSelectedClass] = useState(null);
   const [selectedTags, setSelectedTags] = useState([]);
+  const [config, setConfig] = useState(defaultBenchmarks);
+  const [historySnapshots, setHistorySnapshots] = useState([]);
 
   const toggleTag = (tag) => {
     setSelectedTags((prev) =>
@@ -33,6 +36,10 @@ export const AppProvider = ({ children }) => {
     () => ({
       fundData,
       setFundData,
+      config,
+      setConfig,
+      historySnapshots,
+      setHistorySnapshots,
       availableClasses,
       availableTags,
       selectedClass,
@@ -41,7 +48,7 @@ export const AppProvider = ({ children }) => {
       toggleTag,
       resetFilters,
     }),
-    [fundData, availableClasses, availableTags, selectedClass, selectedTags]
+    [fundData, config, historySnapshots, availableClasses, availableTags, selectedClass, selectedTags]
   );
 
   return <AppContext.Provider value={value}>{children}</AppContext.Provider>;

--- a/src/services/exportService.js
+++ b/src/services/exportService.js
@@ -6,16 +6,16 @@ import 'jspdf-autotable';
 
 /**
  * Export an array of fund objects to an Excel (.xlsx) file.
- * @param {Array<Object>} funds - Scored and tagged fund objects
+ * @param {Array<Object>} filteredFunds - Scored and tagged fund objects
  * @param {string} [filename] - Optional filename for download
  */
-export function exportToExcel(funds, filename) {
-  if (!Array.isArray(funds) || funds.length === 0) return;
+export function exportToExcel(filteredFunds, filename) {
+  if (!Array.isArray(filteredFunds) || filteredFunds.length === 0) return;
 
   const dateStr = new Date().toISOString().split('T')[0];
   const safeName = filename || `Fund_Export_${dateStr}.xlsx`;
 
-  const rows = funds.map(fund => ({
+  const rows = filteredFunds.map(fund => ({
     Symbol: fund.cleanSymbol || fund.Symbol || fund.symbol || '',
     'Fund Name': fund['Fund Name'] || fund.name || '',
     'Asset Class': fund['Asset Class'] || fund.assetClass || '',


### PR DESCRIPTION
## Summary
- include `historySnapshots` context in App component
- store and load monthly snapshot history in localStorage
- record each monthly upload in `historySnapshots`

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68548199a2f48329b46544101f4e3031