### PR TITLE
Fix duplicate config state

### DIFF
--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -12,8 +12,6 @@ export const AppProvider = ({ children }) => {
   /* ---------- filter state ---------- */
   const [selectedClass, setSelectedClass] = useState(null);
   const [selectedTags, setSelectedTags] = useState([]);
-  const [config, setConfig] = useState(defaultBenchmarks);
-  const [historySnapshots, setHistorySnapshots] = useState([]);
 
   const toggleTag = tag =>
     setSelectedTags(prev =>


### PR DESCRIPTION
## Summary
- remove duplicate config state declarations in `AppContext`

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854c496eb4483298cfab3d725cf1192