### PR TITLE
Fix asset class lookup and test

### DIFF
--- a/data/FundListAssetClasses.csv
+++ b/data/FundListAssetClasses.csv
@@ -34,6 +34,7 @@ JQUA,JP Morgan US Quality Factor ETF,Large Cap Blend
 PRDGX,T. Rowe Price Dividend Growth,Large Cap Blend
 RSP,Invesco Equal Weighted S&P 500 ETF,Large Cap Blend
 CEYIX,Calvert Equity,Large Cap Blend
+VFIAX,Vanguard 500 Index Admiral,Large Cap Blend
 FDYZX,Franklin Dynatech Adv,Large Cap Growth
 MFEIX,MFS Growth I,Large Cap Growth
 SPYG,SPDR S&P 500 Growth ETF,Large Cap Growth

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,6 +17,7 @@ import {
 } from './services/scoring';
 import { applyTagRules } from './services/tagEngine';
 import dataStore from './services/dataStore';
+import { loadAssetClassMap, lookupAssetClass } from './services/dataLoader';
 import FundView from './components/Views/FundView.jsx';
 import DashboardView from './components/Views/DashboardView.jsx';
 import AppContext from './context/AppContext.jsx';
@@ -118,6 +119,11 @@ const App = () => {
   useEffect(() => {
     localStorage.setItem('ls_history', JSON.stringify(historySnapshots));
   }, [historySnapshots]);
+
+  // Initialize configuration
+  useEffect(() => {
+    loadAssetClassMap().catch(err => console.error('Error loading asset class map', err));
+  }, []);
 
   // Initialize configuration
   useEffect(() => {
@@ -234,15 +240,18 @@ const App = () => {
             }
           });
 
+          const assetClass = recommendedMatch
+            ? recommendedMatch.assetClass
+            : benchmarkForClass
+              ? benchmarkForClass
+              : lookupAssetClass(parsedSymbol);
+
           return {
             ...f,
             Symbol: f.Symbol,
             cleanSymbol: parsedSymbol,
-            'Asset Class': recommendedMatch
-              ? recommendedMatch.assetClass
-              : benchmarkForClass
-                ? benchmarkForClass
-                : 'Unknown',
+            'Asset Class': assetClass,
+            assetClass,
             isRecommended: !!recommendedMatch,
             isBenchmark: isBenchmark,
             benchmarkForClass: benchmarkForClass,

--- a/src/services/__tests__/mapping.test.js
+++ b/src/services/__tests__/mapping.test.js
@@ -1,0 +1,15 @@
+import { loadAssetClassMap, lookupAssetClass, clearAssetClassMap } from '../dataLoader';
+
+describe('asset class mapping', () => {
+  beforeAll(async () => {
+    await loadAssetClassMap();
+  });
+
+  afterAll(() => {
+    clearAssetClassMap();
+  });
+
+  test('VFIAX resolves to Large Cap Blend', () => {
+    expect(lookupAssetClass('VFIAX')).toBe('Large Cap Blend');
+  });
+});

--- a/src/services/dataLoader.js
+++ b/src/services/dataLoader.js
@@ -1,0 +1,52 @@
+import Papa from 'papaparse';
+
+let assetClassMap = null;
+
+function parseMap(csvText) {
+  const parsed = Papa.parse(csvText.trim(), { header: true });
+  const map = new Map();
+  parsed.data.forEach(row => {
+    if (!row['Fund Ticker']) return;
+    const symbol = row['Fund Ticker'].toString().trim().toUpperCase();
+    const cls = (row['Asset Class'] || 'Unknown').trim();
+    if (symbol) {
+      map.set(symbol, cls);
+    }
+  });
+  return map;
+}
+
+export async function loadAssetClassMap() {
+  if (assetClassMap) return assetClassMap;
+
+  if (typeof fetch === 'function' && !process.env.JEST_WORKER_ID) {
+    try {
+      const res = await fetch('/data/FundListAssetClasses.csv');
+      if (res.ok) {
+        const csv = await res.text();
+        assetClassMap = parseMap(csv);
+        return assetClassMap;
+      }
+    } catch (e) {
+      // fall back to filesystem
+    }
+  }
+
+  const fs = require('fs');
+  const path = require('path');
+  const filePath = path.resolve(__dirname, '../../data/FundListAssetClasses.csv');
+  const csv = fs.readFileSync(filePath, 'utf-8');
+  assetClassMap = parseMap(csv);
+  return assetClassMap;
+}
+
+export function lookupAssetClass(symbol) {
+  if (!assetClassMap || !symbol) return 'Unknown';
+  const key = symbol.toString().trim().toUpperCase();
+  return assetClassMap.get(key) || 'Unknown';
+}
+
+export function clearAssetClassMap() {
+  assetClassMap = null;
+}
+


### PR DESCRIPTION
## Summary
- add missing VFIAX asset class record
- load asset class map via new dataLoader service
- wire lookupAssetClass into file upload flow
- provide unit test for asset class lookup

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68555ad4a65083299831def8d065cfac