### PR TITLE
Fix asset class lookup export and browser parsing test

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,7 +16,7 @@ import {
 } from './services/scoring';
 import { applyTagRules } from './services/tagEngine';
 import dataStore from './services/dataStore';
-import { loadAssetClassMap } from './services/dataLoader';
+import { loadAssetClassMap, lookupAssetClass } from './services/dataLoader';
 import parseFundFile from './services/parseFundFile';
 import FundScores from './components/Views/FundScores.jsx';
 import DashboardView from './components/Views/DashboardView.jsx';

--- a/src/services/__tests__/parseDoesNotThrow.browser.test.js
+++ b/src/services/__tests__/parseDoesNotThrow.browser.test.js
@@ -1,0 +1,13 @@
+import parseFundFile from '../parseFundFile';
+import fs from 'fs';
+import path from 'path';
+import * as XLSX from 'xlsx';
+
+test('parseFundFile does not throw for browser CSV sample', async () => {
+  const csvPath = path.resolve(__dirname, '../../../data/Fund_Performance_Data.csv');
+  const csv = fs.readFileSync(csvPath, 'utf8');
+  const wb = XLSX.read(csv, { type: 'string' });
+  const sheet = wb.Sheets[wb.SheetNames[0]];
+  const rows = XLSX.utils.sheet_to_json(sheet, { header: 1 });
+  await expect(parseFundFile(rows)).resolves.toBeDefined();
+});

--- a/src/services/dataLoader.js
+++ b/src/services/dataLoader.js
@@ -16,7 +16,7 @@ function parseMap(csvText) {
   return map;
 }
 
-export async function loadAssetClassMap() {
+async function loadAssetClassMap() {
   if (assetClassMap) return assetClassMap;
 
   if (process.env.NODE_ENV === 'test') {
@@ -46,11 +46,14 @@ export async function loadAssetClassMap() {
   return assetClassMap;
 }
 
-export function lookupAssetClass(symbol) {
-  if (!assetClassMap || !symbol) return 'Unknown';
+function lookupAssetClass(symbol) {
+  if (!assetClassMap || !symbol) return null;
   const key = symbol.toString().trim().toUpperCase();
-  return assetClassMap.get(key) || 'Unknown';
+  return assetClassMap.get(key) || null;
 }
+
+export { loadAssetClassMap, lookupAssetClass };
+
 
 export function clearAssetClassMap() {
   assetClassMap = null;

--- a/src/services/parseFundFile.js
+++ b/src/services/parseFundFile.js
@@ -75,7 +75,7 @@ export default async function parseFundFile(rows, options = {}) {
     }
     if (!assetClass) {
       const lookedUp = lookupAssetClass(symbolClean);
-      assetClass = lookedUp || 'Unknown';
+      assetClass = lookedUp == null ? 'Unknown' : lookedUp;
     }
 
     const assetClassFinal = assetClass || 'Unknown';


### PR DESCRIPTION
## Summary
- ensure `lookupAssetClass` exported for browser usage
- import the helper in `App.jsx`
- guard `parseFundFile` when lookup returns null
- add integration test loading the real CSV

## Testing
- `npm test -- --watchAll=false`
- `npm start` *(ends with webpack compiled with warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68559cc64a288329b170ad1fe45293ec