### PR TITLE
Fix asset class scoring and benchmark row

### DIFF
--- a/src/components/BenchmarkRow.jsx
+++ b/src/components/BenchmarkRow.jsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { getScoreColor, getScoreLabel } from '../services/scoring';
+
+const ScoreBadge = ({ score }) => {
+  const color = getScoreColor(score);
+  const label = getScoreLabel(score);
+  return (
+    <span
+      style={{
+        backgroundColor: `${color}20`,
+        color,
+        border: `1px solid ${color}50`,
+        borderRadius: '9999px',
+        fontSize: '0.75rem',
+        padding: '0.25rem 0.5rem',
+        display: 'inline-block',
+        minWidth: '3rem',
+        textAlign: 'center'
+      }}
+    >
+      {score} - {label}
+    </span>
+  );
+};
+
+const BenchmarkRow = ({ data }) => {
+  if (!data) return null;
+  return (
+    <tr style={{ backgroundColor: '#f3f4f6', fontWeight: 600 }}>
+      <td style={{ padding: '0.75rem' }}>
+        {data.Symbol}
+        <span
+          style={{
+            marginLeft: '0.5rem',
+            backgroundColor: '#e5e7eb',
+            color: '#374151',
+            padding: '0.125rem 0.5rem',
+            borderRadius: '0.25rem',
+            fontSize: '0.75rem',
+            fontWeight: '500'
+          }}
+        >
+          Benchmark
+        </span>
+      </td>
+      <td style={{ padding: '0.75rem' }}>{data['Fund Name'] || data.name}</td>
+      <td style={{ padding: '0.75rem', textAlign: 'center' }}>
+        {data.scores ? <ScoreBadge score={data.scores.final} /> : '-'}
+      </td>
+      <td style={{ padding: '0.75rem', textAlign: 'right' }}>
+        {data.YTD != null ? `${data.YTD.toFixed(2)}%` : 'N/A'}
+      </td>
+      <td style={{ padding: '0.75rem', textAlign: 'right' }}>
+        {data['1 Year'] != null ? `${data['1 Year'].toFixed(2)}%` : 'N/A'}
+      </td>
+      <td style={{ padding: '0.75rem', textAlign: 'right' }}>
+        {data['3 Year'] != null ? `${data['3 Year'].toFixed(2)}%` : 'N/A'}
+      </td>
+      <td style={{ padding: '0.75rem', textAlign: 'right' }}>
+        {data['5 Year'] != null ? `${data['5 Year'].toFixed(2)}%` : 'N/A'}
+      </td>
+      <td style={{ padding: '0.75rem', textAlign: 'right' }}>
+        {data['Sharpe Ratio']?.toFixed(2) ?? 'N/A'}
+      </td>
+      <td style={{ padding: '0.75rem', textAlign: 'right' }}>
+        {data['Standard Deviation']?.toFixed(2) ?? 'N/A'}%
+      </td>
+      <td style={{ padding: '0.75rem', textAlign: 'right' }}>
+        {data['Net Expense Ratio']?.toFixed(2) ?? 'N/A'}%
+      </td>
+    </tr>
+  );
+};
+
+export default BenchmarkRow;

--- a/src/components/FundTable.jsx
+++ b/src/components/FundTable.jsx
@@ -32,13 +32,14 @@ const FundTable = ({ funds = [], onRowClick = () => {} }) => (
         <tr style={{ borderBottom: '2px solid #e5e7eb' }}>
           <th style={{ padding: '0.75rem', textAlign: 'left' }}>Symbol</th>
           <th style={{ padding: '0.75rem', textAlign: 'left' }}>Fund Name</th>
-          <th style={{ padding: '0.75rem', textAlign: 'left' }}>Asset Class</th>
           <th style={{ padding: '0.75rem', textAlign: 'center' }}>Score</th>
-          <th style={{ padding: '0.75rem', textAlign: 'right' }}>1Y Return</th>
+          <th style={{ padding: '0.75rem', textAlign: 'right' }}>YTD</th>
+          <th style={{ padding: '0.75rem', textAlign: 'right' }}>1Y</th>
+          <th style={{ padding: '0.75rem', textAlign: 'right' }}>3Y</th>
+          <th style={{ padding: '0.75rem', textAlign: 'right' }}>5Y</th>
           <th style={{ padding: '0.75rem', textAlign: 'right' }}>Sharpe</th>
           <th style={{ padding: '0.75rem', textAlign: 'right' }}>Std Dev (5Y)</th>
           <th style={{ padding: '0.75rem', textAlign: 'right' }}>Expense</th>
-          <th style={{ padding: '0.75rem', textAlign: 'left' }}>Type</th>
           <th style={{ padding: '0.75rem', textAlign: 'left' }}>Tags</th>
         </tr>
       </thead>
@@ -54,23 +55,30 @@ const FundTable = ({ funds = [], onRowClick = () => {} }) => (
           >
             <td style={{ padding: '0.5rem' }}>{fund.Symbol}</td>
             <td style={{ padding: '0.5rem' }}>{fund['Fund Name']}</td>
-            <td style={{ padding: '0.5rem' }}>{fund['Asset Class']}</td>
             <td style={{ padding: '0.5rem', textAlign: 'center' }}>
               {fund.scores ? <ScoreBadge score={fund.scores.final} /> : '-'}
+            </td>
+            <td style={{ padding: '0.5rem', textAlign: 'right' }}>
+              {formatPercent(fund.YTD)}
             </td>
             <td style={{ padding: '0.5rem', textAlign: 'right' }}>
               {formatPercent(fund['1 Year'])}
             </td>
             <td style={{ padding: '0.5rem', textAlign: 'right' }}>
+              {formatPercent(fund['3 Year'])}
+            </td>
+            <td style={{ padding: '0.5rem', textAlign: 'right' }}>
+              {formatPercent(fund['5 Year'])}
+            </td>
+            <td style={{ padding: '0.5rem', textAlign: 'right' }}>
               {fund['Sharpe Ratio'] != null ? fund['Sharpe Ratio'].toFixed(2) : 'N/A'}
             </td>
             <td style={{ padding: '0.5rem', textAlign: 'right' }}>
-              {fund['Std Dev (5Y)'] != null ? `${fund['Std Dev (5Y)'].toFixed(2)}%` : 'N/A'}
+              {fund['Standard Deviation'] != null ? `${fund['Standard Deviation'].toFixed(2)}%` : 'N/A'}
             </td>
             <td style={{ padding: '0.5rem', textAlign: 'right' }}>
-              {formatPercent(fund.Expense)}
+              {formatPercent(fund['Net Expense Ratio'])}
             </td>
-            <td style={{ padding: '0.5rem' }}>{fund.Type || 'N/A'}</td>
             <td style={{ padding: '0.5rem' }}>
               {Array.isArray(fund.tags) && fund.tags.length > 0 ? (
                 <TagList tags={fund.tags} />

--- a/src/components/__tests__/ClassView.test.jsx
+++ b/src/components/__tests__/ClassView.test.jsx
@@ -1,0 +1,26 @@
+import { render, screen, within } from '@testing-library/react';
+import BenchmarkRow from '../BenchmarkRow.jsx';
+
+const funds = [
+  { Symbol: 'IWF', 'Fund Name': 'Russell 1000 Growth', scores: { final: 60 }, YTD: 3 },
+  { Symbol: 'AAA', 'Fund Name': 'Fund A', scores: { final: 70 }, '1 Year': 12 },
+];
+
+test('benchmark row renders first', () => {
+  render(
+    <table>
+      <tbody>
+        <BenchmarkRow data={funds[0]} />
+        {funds.slice(1).map(f => (
+          <tr key={f.Symbol}>
+            <td>{f.Symbol}</td>
+            <td>{f['Fund Name']}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+
+  const rows = within(screen.getByRole('rowgroup')).getAllByRole('row');
+  expect(rows[0].textContent).toContain('Benchmark');
+});

--- a/src/components/__tests__/FundTable.interaction.test.jsx
+++ b/src/components/__tests__/FundTable.interaction.test.jsx
@@ -8,11 +8,13 @@ test('row click calls handler', async () => {
     'Fund Name': 'XYZ Fund',
     'Asset Class': 'Bond',
     scores: { final: 60 },
+    YTD: 1,
     '1 Year': 5,
+    '3 Year': 6,
+    '5 Year': 7,
     'Sharpe Ratio': 0.5,
-    'Std Dev (5Y)': 12,
-    Expense: 0.3,
-    Type: 'ETF',
+    'Standard Deviation': 12,
+    'Net Expense Ratio': 0.3,
     tags: []
   };
   const handler = jest.fn();

--- a/src/components/__tests__/FundTable.test.jsx
+++ b/src/components/__tests__/FundTable.test.jsx
@@ -6,11 +6,13 @@ const sample = [{
   'Fund Name': 'Alpha Fund',
   'Asset Class': 'Large Cap',
   scores: { final: 75 },
+  YTD: 2,
   '1 Year': 10,
+  '3 Year': 12,
+  '5 Year': 15,
   'Sharpe Ratio': 0.8,
-  'Std Dev (5Y)': 15,
-  Expense: 0.5,
-  Type: 'MF',
+  'Standard Deviation': 18,
+  'Net Expense Ratio': 0.5,
   tags: ['outperformer']
 }];
 

--- a/src/components/__tests__/__snapshots__/FundTable.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/FundTable.test.jsx.snap
@@ -23,11 +23,6 @@ exports[`renders table snapshot 1`] = `
             Fund Name
           </th>
           <th
-            style="padding: 0.75rem; text-align: left;"
-          >
-            Asset Class
-          </th>
-          <th
             style="padding: 0.75rem; text-align: center;"
           >
             Score
@@ -35,7 +30,22 @@ exports[`renders table snapshot 1`] = `
           <th
             style="padding: 0.75rem; text-align: right;"
           >
-            1Y Return
+            YTD
+          </th>
+          <th
+            style="padding: 0.75rem; text-align: right;"
+          >
+            1Y
+          </th>
+          <th
+            style="padding: 0.75rem; text-align: right;"
+          >
+            3Y
+          </th>
+          <th
+            style="padding: 0.75rem; text-align: right;"
+          >
+            5Y
           </th>
           <th
             style="padding: 0.75rem; text-align: right;"
@@ -51,11 +61,6 @@ exports[`renders table snapshot 1`] = `
             style="padding: 0.75rem; text-align: right;"
           >
             Expense
-          </th>
-          <th
-            style="padding: 0.75rem; text-align: left;"
-          >
-            Type
           </th>
           <th
             style="padding: 0.75rem; text-align: left;"
@@ -81,11 +86,6 @@ exports[`renders table snapshot 1`] = `
             Alpha Fund
           </td>
           <td
-            style="padding: 0.5rem;"
-          >
-            Large Cap
-          </td>
-          <td
             style="padding: 0.5rem; text-align: center;"
           >
             <span
@@ -97,12 +97,17 @@ exports[`renders table snapshot 1`] = `
           <td
             style="padding: 0.5rem; text-align: right;"
           >
+            2.00%
+          </td>
+          <td
+            style="padding: 0.5rem; text-align: right;"
+          >
             10.00%
           </td>
           <td
             style="padding: 0.5rem; text-align: right;"
           >
-            0.80
+            12.00%
           </td>
           <td
             style="padding: 0.5rem; text-align: right;"
@@ -112,12 +117,17 @@ exports[`renders table snapshot 1`] = `
           <td
             style="padding: 0.5rem; text-align: right;"
           >
-            0.50%
+            0.80
           </td>
           <td
-            style="padding: 0.5rem;"
+            style="padding: 0.5rem; text-align: right;"
           >
-            MF
+            18.00%
+          </td>
+          <td
+            style="padding: 0.5rem; text-align: right;"
+          >
+            0.50%
           </td>
           <td
             style="padding: 0.5rem;"

--- a/src/services/__tests__/benchmarkRow.integration.test.js
+++ b/src/services/__tests__/benchmarkRow.integration.test.js
@@ -1,0 +1,34 @@
+import fs from 'fs';
+import path from 'path';
+import * as XLSX from 'xlsx';
+import parseFundFile from '../parseFundFile';
+import { recommendedFunds, assetClassBenchmarks } from '../../data/config';
+import { calculateScores } from '../scoring';
+
+const clean = s => s?.toUpperCase().trim().replace(/[^A-Z0-9]/g, '');
+
+test('Large Cap Growth benchmark included with metrics', async () => {
+  const csvPath = path.resolve(__dirname, '../../../data/Fund_Performance_Data.csv');
+  const csv = fs.readFileSync(csvPath, 'utf8');
+  const wb = XLSX.read(csv, { type: 'string' });
+  const rows = XLSX.utils.sheet_to_json(wb.Sheets[wb.SheetNames[0]], { header: 1 });
+  const parsed = await parseFundFile(rows, { recommendedFunds, assetClassBenchmarks });
+  const withFlags = parsed.map(f => {
+    const symbol = clean(f.Symbol);
+    let benchmarkForClass = null;
+    Object.entries(assetClassBenchmarks).forEach(([ac, b]) => {
+      if (clean(b.ticker) === symbol) benchmarkForClass = ac;
+    });
+    return {
+      ...f,
+      cleanSymbol: symbol,
+      isBenchmark: benchmarkForClass != null,
+      benchmarkForClass,
+    };
+  });
+  const scored = calculateScores(withFlags);
+  const bench = scored.find(f => f.isBenchmark && f.benchmarkForClass === 'Large Cap Growth');
+  expect(bench).toBeDefined();
+  expect(bench.Symbol).toBe('IWF');
+  expect(typeof bench['1 Year']).toBe('number');
+});

--- a/src/services/__tests__/parseDoesNotThrow.browser.test.js
+++ b/src/services/__tests__/parseDoesNotThrow.browser.test.js
@@ -1,0 +1,13 @@
+import parseFundFile from '../parseFundFile';
+import fs from 'fs';
+import path from 'path';
+import * as XLSX from 'xlsx';
+
+test('parseFundFile does not throw for browser CSV sample', async () => {
+  const csvPath = path.resolve(__dirname, '../../../data/Fund_Performance_Data.csv');
+  const csv = fs.readFileSync(csvPath, 'utf8');
+  const wb = XLSX.read(csv, { type: 'string' });
+  const sheet = wb.Sheets[wb.SheetNames[0]];
+  const rows = XLSX.utils.sheet_to_json(sheet, { header: 1 });
+  await expect(parseFundFile(rows)).resolves.toBeDefined();
+});

--- a/src/services/__tests__/parseFundFile.test.js
+++ b/src/services/__tests__/parseFundFile.test.js
@@ -17,9 +17,9 @@ describe('parseFundFile', () => {
       ['APDJX', 'Artisan International Small-Mid', '0.12', 'MF', '18.05']
     ];
     const result = await parseFundFile(rows);
-    expect(result[0].Expense).toBeCloseTo(0.04);
+    expect(result[0]['Net Expense Ratio']).toBeCloseTo(0.04);
     expect(result[0].Type).toBe('MF');
-    expect(result[0]['Std Dev (5Y)']).toBeCloseTo(18.05);
+    expect(result[0]['Standard Deviation']).toBeCloseTo(18.05);
     expect(result[0]['Asset Class']).toBe('Large Cap Blend');
     expect(result[1]['Asset Class']).toBe('International Stock (Small/Mid Cap)');
   });

--- a/src/services/__tests__/parseMetrics.test.js
+++ b/src/services/__tests__/parseMetrics.test.js
@@ -1,0 +1,17 @@
+import fs from 'fs';
+import path from 'path';
+import * as XLSX from 'xlsx';
+import parseFundFile from '../parseFundFile';
+import { recommendedFunds, assetClassBenchmarks } from '../../data/config';
+
+test('BUYZ metrics parsed correctly', async () => {
+  const csvPath = path.resolve(__dirname, '../../../data/Fund_Performance_Data.csv');
+  const csv = fs.readFileSync(csvPath, 'utf8');
+  const wb = XLSX.read(csv, { type: 'string' });
+  const rows = XLSX.utils.sheet_to_json(wb.Sheets[wb.SheetNames[0]], { header: 1 });
+  const result = await parseFundFile(rows, { recommendedFunds, assetClassBenchmarks });
+  const buyz = result.find(r => r.Symbol === 'BUYZ');
+  expect(buyz).toBeDefined();
+  expect(buyz['Net Expense Ratio']).toBeCloseTo(0.5);
+  expect(typeof buyz['3 Year']).toBe('number');
+});

--- a/src/services/__tests__/scoringPerClass.test.js
+++ b/src/services/__tests__/scoringPerClass.test.js
@@ -1,0 +1,52 @@
+import { calculateScores, generateClassSummary } from '../scoring';
+
+describe('per-class scoring with benchmark integration', () => {
+  test('benchmark scored within its asset class', () => {
+    const sample = [
+      {
+        Symbol: 'AAA',
+        'Fund Name': 'Fund A',
+        'Asset Class': 'Large Cap Growth',
+        '1 Year': 12,
+        '3 Year': 14,
+        '5 Year': 16,
+        'Sharpe Ratio': 1.2,
+        'Standard Deviation': 15,
+        'Net Expense Ratio': 0.5,
+        isBenchmark: false
+      },
+      {
+        Symbol: 'BBB',
+        'Fund Name': 'Fund B',
+        'Asset Class': 'Large Cap Growth',
+        '1 Year': 8,
+        '3 Year': 9,
+        '5 Year': 10,
+        'Sharpe Ratio': 0.8,
+        'Standard Deviation': 18,
+        'Net Expense Ratio': 0.6,
+        isBenchmark: false
+      },
+      {
+        Symbol: 'IWF',
+        'Fund Name': 'Russell 1000 Growth',
+        'Asset Class': 'Large Cap Growth',
+        '1 Year': 10,
+        '3 Year': 11,
+        '5 Year': 12,
+        'Sharpe Ratio': 1.0,
+        'Standard Deviation': 16,
+        'Net Expense Ratio': 0.2,
+        isBenchmark: true
+      }
+    ];
+
+    const scored = calculateScores(sample);
+    const summary = generateClassSummary(scored);
+    const benchmark = scored.find(f => f.isBenchmark);
+
+    expect(typeof benchmark.scores.final).toBe('number');
+    expect(summary.benchmarkScore).toBeCloseTo(benchmark.scores.final);
+    expect(summary.fundCount).toBe(2); // peers only
+  });
+});

--- a/src/services/dataLoader.js
+++ b/src/services/dataLoader.js
@@ -16,7 +16,7 @@ function parseMap(csvText) {
   return map;
 }
 
-export async function loadAssetClassMap() {
+async function loadAssetClassMap() {
   if (assetClassMap) return assetClassMap;
 
   if (process.env.NODE_ENV === 'test') {
@@ -46,11 +46,14 @@ export async function loadAssetClassMap() {
   return assetClassMap;
 }
 
-export function lookupAssetClass(symbol) {
-  if (!assetClassMap || !symbol) return 'Unknown';
+function lookupAssetClass(symbol) {
+  if (!assetClassMap || !symbol) return null;
   const key = symbol.toString().trim().toUpperCase();
-  return assetClassMap.get(key) || 'Unknown';
+  return assetClassMap.get(key) || null;
 }
+
+export { loadAssetClassMap, lookupAssetClass };
+
 
 export function clearAssetClassMap() {
   assetClassMap = null;

--- a/src/services/parseFundFile.js
+++ b/src/services/parseFundFile.js
@@ -24,11 +24,14 @@ export default async function parseFundFile(rows, options = {}) {
     if (headerLower.includes('symbol')) columnMap.Symbol = idx;
     if (headerLower.includes('product name')) columnMap['Fund Name'] = idx;
     if (headerLower === 'asset class') columnMap['Asset Class'] = idx;
+    if (headerLower.includes('ytd')) columnMap.YTD = idx;
     if (headerLower.includes('1 year')) columnMap['1 Year'] = idx;
+    if (headerLower.includes('3 year')) columnMap['3 Year'] = idx;
+    if (headerLower.includes('5 year')) columnMap['5 Year'] = idx;
     if (headerLower.includes('sharpe')) columnMap['Sharpe Ratio'] = idx;
-    if (headerLower.includes('standard deviation - 5')) columnMap['Std Dev (5Y)'] = idx;
-    if (headerLower.includes('standard deviation - 3')) columnMap['Std Dev (3Y)'] = idx;
-    if (headerLower.includes('net exp')) columnMap.expense = idx;
+    if (headerLower.includes('standard deviation - 5')) columnMap['Standard Deviation'] = idx;
+    if (headerLower.includes('net exp')) columnMap['Net Expense Ratio'] = idx;
+    if (headerLower.includes('manager tenure')) columnMap['Manager Tenure'] = idx;
     if (headerLower.includes('vehicle type') || headerLower === 'type') columnMap.type = idx;
   });
 
@@ -47,7 +50,13 @@ export default async function parseFundFile(rows, options = {}) {
       const obj = {};
       Object.entries(columnMap).forEach(([key, idx]) => {
         const val = row[idx];
-        if (key === 'expense' || key.startsWith('Std Dev') || key === 'Sharpe Ratio' || key === '1 Year') {
+        if (
+          key === 'Net Expense Ratio' ||
+          key === 'Manager Tenure' ||
+          key === 'Sharpe Ratio' ||
+          key.includes('Year') ||
+          key.includes('Deviation')
+        ) {
           obj[key] = cleanNumber(val);
         } else {
           obj[key] = cleanText(val);
@@ -75,7 +84,7 @@ export default async function parseFundFile(rows, options = {}) {
     }
     if (!assetClass) {
       const lookedUp = lookupAssetClass(symbolClean);
-      assetClass = lookedUp || 'Unknown';
+      assetClass = lookedUp == null ? 'Unknown' : lookedUp;
     }
 
     const assetClassFinal = assetClass || 'Unknown';
@@ -85,10 +94,14 @@ export default async function parseFundFile(rows, options = {}) {
       'Fund Name': f['Fund Name'],
       'Asset Class': assetClassFinal,
       assetClass: assetClassFinal,
+      YTD: f.YTD,
       '1 Year': f['1 Year'],
+      '3 Year': f['3 Year'],
+      '5 Year': f['5 Year'],
       'Sharpe Ratio': f['Sharpe Ratio'],
-      'Std Dev (5Y)': f['Std Dev (5Y)'],
-      Expense: f.expense,
+      'Standard Deviation': f['Standard Deviation'],
+      'Net Expense Ratio': f['Net Expense Ratio'],
+      'Manager Tenure': f['Manager Tenure'],
       Type: f.type || '',
     };
   });

--- a/src/utils/__tests__/benchmarks.test.js
+++ b/src/utils/__tests__/benchmarks.test.js
@@ -1,0 +1,5 @@
+import { lookupBenchmarkTicker } from '../benchmarks';
+
+test('lookupBenchmarkTicker returns correct symbol', () => {
+  expect(lookupBenchmarkTicker('Large Cap Growth')).toBe('IWF');
+});

--- a/src/utils/benchmarks.js
+++ b/src/utils/benchmarks.js
@@ -1,0 +1,8 @@
+export { lookupBenchmarkTicker };
+
+import { assetClassBenchmarks } from '../data/config';
+
+function lookupBenchmarkTicker(assetClass) {
+  const entry = assetClassBenchmarks[assetClass];
+  return entry ? entry.ticker : null;
+}


### PR DESCRIPTION
## Summary
- parse YTD, 3Y, 5Y, expense and std dev columns
- ensure benchmark rows are injected and scored per class
- add helper for looking up benchmark tickers
- extend FundTable columns with YTD and multi-year returns
- display full metrics in `BenchmarkRow`
- new tests for benchmark and parser behaviour

## Testing
- `npm test -- --watchAll=false`
- `npm start` *(compiled successfully)*

------
https://chatgpt.com/codex/tasks/task_e_68559cc64a288329b170ad1fe45293ec