### PR TITLE
Fix metric parsing and formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## [Unreleased]
+- Normalize numeric fields when parsing fund files.
+- Added `fmtPct` and `fmtNumber` helpers and updated components to use them.
+- Added tests for parser normalization and Class View rendering.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -18,6 +18,7 @@ import { applyTagRules } from './services/tagEngine';
 import dataStore from './services/dataStore';
 import { loadAssetClassMap, lookupAssetClass } from './services/dataLoader';
 import parseFundFile from './services/parseFundFile';
+import { fmtPct, fmtNumber } from './utils/formatters';
 import FundScores from './components/Views/FundScores.jsx';
 import DashboardView from './components/Views/DashboardView.jsx';
 import BenchmarkRow from './components/BenchmarkRow.jsx';
@@ -701,25 +702,25 @@ const App = () => {
                             ) : '-'}
                           </td>
                           <td style={{ padding: '0.75rem', textAlign: 'right' }}>
-                            {fund.YTD != null ? `${fund.YTD.toFixed(2)}%` : 'N/A'}
+                            {fmtPct(fund.ytd ?? fund.YTD)}
                           </td>
                           <td style={{ padding: '0.75rem', textAlign: 'right' }}>
-                            {fund['1 Year'] != null ? `${fund['1 Year'].toFixed(2)}%` : 'N/A'}
+                            {fmtPct(fund.oneYear ?? fund['1 Year'])}
                           </td>
                           <td style={{ padding: '0.75rem', textAlign: 'right' }}>
-                            {fund['3 Year'] != null ? `${fund['3 Year'].toFixed(2)}%` : 'N/A'}
+                            {fmtPct(fund.threeYear ?? fund['3 Year'])}
                           </td>
                           <td style={{ padding: '0.75rem', textAlign: 'right' }}>
-                            {fund['5 Year'] != null ? `${fund['5 Year'].toFixed(2)}%` : 'N/A'}
+                            {fmtPct(fund.fiveYear ?? fund['5 Year'])}
                           </td>
                           <td style={{ padding: '0.75rem', textAlign: 'right' }}>
-                            {fund['Sharpe Ratio'] != null ? fund['Sharpe Ratio'].toFixed(2) : 'N/A'}
+                            {fmtNumber(fund.sharpe ?? fund['Sharpe Ratio'])}
                           </td>
                           <td style={{ padding: '0.75rem', textAlign: 'right' }}>
-                            {fund['Standard Deviation'] != null ? `${fund['Standard Deviation'].toFixed(2)}%` : 'N/A'}
+                            {fmtPct(fund.stdDev5y ?? fund['Standard Deviation'])}
                           </td>
                           <td style={{ padding: '0.75rem', textAlign: 'right' }}>
-                            {fund['Net Expense Ratio'] != null ? `${fund['Net Expense Ratio'].toFixed(2)}%` : 'N/A'}
+                            {fmtPct(fund.expense ?? fund['Net Expense Ratio'])}
                           </td>
                       </tr>
                     ))}
@@ -802,15 +803,15 @@ const App = () => {
                     }}>
                       <div>
                         <span style={{ color: '#6b7280' }}>1Y Return:</span>{' '}
-                        <strong>{fund['1 Year']?.toFixed(2) ?? 'N/A'}%</strong>
+                        <strong>{fmtPct(fund.oneYear ?? fund['1 Year'])}</strong>
                       </div>
                       <div>
                         <span style={{ color: '#6b7280' }}>Sharpe:</span>{' '}
-                        <strong>{fund['Sharpe Ratio']?.toFixed(2) ?? 'N/A'}</strong>
+                        <strong>{fmtNumber(fund.sharpe ?? fund['Sharpe Ratio'])}</strong>
                       </div>
                       <div>
                         <span style={{ color: '#6b7280' }}>Expense:</span>{' '}
-                        <strong>{fund['Net Expense Ratio']?.toFixed(2) ?? 'N/A'}%</strong>
+                        <strong>{fmtPct(fund.expense ?? fund['Net Expense Ratio'])}</strong>
                       </div>
                     </div>
                   </div>

--- a/src/components/BenchmarkRow.jsx
+++ b/src/components/BenchmarkRow.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { getScoreColor, getScoreLabel } from '../services/scoring';
+import { fmtPct, fmtNumber } from '../utils/formatters';
 
 const ScoreBadge = ({ score }) => {
   const color = getScoreColor(score);
@@ -48,25 +49,25 @@ const BenchmarkRow = ({ data }) => {
         {data.scores ? <ScoreBadge score={data.scores.final} /> : '-'}
       </td>
       <td style={{ padding: '0.75rem', textAlign: 'right' }}>
-        {data.YTD != null ? `${data.YTD.toFixed(2)}%` : 'N/A'}
+        {fmtPct(data.ytd ?? data.YTD)}
       </td>
       <td style={{ padding: '0.75rem', textAlign: 'right' }}>
-        {data['1 Year'] != null ? `${data['1 Year'].toFixed(2)}%` : 'N/A'}
+        {fmtPct(data.oneYear ?? data['1 Year'])}
       </td>
       <td style={{ padding: '0.75rem', textAlign: 'right' }}>
-        {data['3 Year'] != null ? `${data['3 Year'].toFixed(2)}%` : 'N/A'}
+        {fmtPct(data.threeYear ?? data['3 Year'])}
       </td>
       <td style={{ padding: '0.75rem', textAlign: 'right' }}>
-        {data['5 Year'] != null ? `${data['5 Year'].toFixed(2)}%` : 'N/A'}
+        {fmtPct(data.fiveYear ?? data['5 Year'])}
       </td>
       <td style={{ padding: '0.75rem', textAlign: 'right' }}>
-        {data['Sharpe Ratio']?.toFixed(2) ?? 'N/A'}
+        {fmtNumber(data.sharpe ?? data['Sharpe Ratio'])}
       </td>
       <td style={{ padding: '0.75rem', textAlign: 'right' }}>
-        {data['Standard Deviation']?.toFixed(2) ?? 'N/A'}%
+        {fmtPct(data.stdDev5y ?? data['Standard Deviation'])}
       </td>
       <td style={{ padding: '0.75rem', textAlign: 'right' }}>
-        {data['Net Expense Ratio']?.toFixed(2) ?? 'N/A'}%
+        {fmtPct(data.expense ?? data['Net Expense Ratio'])}
       </td>
     </tr>
   );

--- a/src/components/FundTable.jsx
+++ b/src/components/FundTable.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import TagList from './TagList.jsx';
 import { getScoreColor, getScoreLabel } from '../services/scoring';
-import { formatPercent } from '../utils/formatters';
+import { fmtPct, fmtNumber } from '../utils/formatters';
 
 const ScoreBadge = ({ score }) => {
   const color = getScoreColor(score);
@@ -59,25 +59,25 @@ const FundTable = ({ funds = [], onRowClick = () => {} }) => (
               {fund.scores ? <ScoreBadge score={fund.scores.final} /> : '-'}
             </td>
             <td style={{ padding: '0.5rem', textAlign: 'right' }}>
-              {formatPercent(fund.YTD)}
+              {fmtPct(fund.ytd ?? fund.YTD)}
             </td>
             <td style={{ padding: '0.5rem', textAlign: 'right' }}>
-              {formatPercent(fund['1 Year'])}
+              {fmtPct(fund.oneYear ?? fund['1 Year'])}
             </td>
             <td style={{ padding: '0.5rem', textAlign: 'right' }}>
-              {formatPercent(fund['3 Year'])}
+              {fmtPct(fund.threeYear ?? fund['3 Year'])}
             </td>
             <td style={{ padding: '0.5rem', textAlign: 'right' }}>
-              {formatPercent(fund['5 Year'])}
+              {fmtPct(fund.fiveYear ?? fund['5 Year'])}
             </td>
             <td style={{ padding: '0.5rem', textAlign: 'right' }}>
-              {fund['Sharpe Ratio'] != null ? fund['Sharpe Ratio'].toFixed(2) : 'N/A'}
+              {fmtNumber(fund.sharpe ?? fund['Sharpe Ratio'])}
             </td>
             <td style={{ padding: '0.5rem', textAlign: 'right' }}>
-              {fund['Standard Deviation'] != null ? `${fund['Standard Deviation'].toFixed(2)}%` : 'N/A'}
+              {fmtPct(fund.stdDev5y ?? fund['Standard Deviation'])}
             </td>
             <td style={{ padding: '0.5rem', textAlign: 'right' }}>
-              {formatPercent(fund['Net Expense Ratio'])}
+              {fmtPct(fund.expense ?? fund['Net Expense Ratio'])}
             </td>
             <td style={{ padding: '0.5rem' }}>
               {Array.isArray(fund.tags) && fund.tags.length > 0 ? (

--- a/src/components/__tests__/ClassViewRender.test.jsx
+++ b/src/components/__tests__/ClassViewRender.test.jsx
@@ -1,0 +1,28 @@
+import { render } from '@testing-library/react';
+import BenchmarkRow from '../BenchmarkRow.jsx';
+import { fmtPct, fmtNumber } from '../../utils/formatters';
+
+const benchmark = { Symbol: 'IWF', 'Fund Name': 'Index', ytd: 1, oneYear: 2, threeYear: 3, fiveYear: 4, sharpe: 1, stdDev5y: 10, expense: 0.2 };
+const fund = { Symbol: 'AAA', 'Fund Name': 'Fund A', ytd: null, oneYear: 5, threeYear: null, fiveYear: 7, sharpe: 0.8, stdDev5y: 12, expense: 0.3 };
+
+test('class view table renders', () => {
+  render(
+    <table>
+      <tbody>
+        <BenchmarkRow data={benchmark} />
+        <tr>
+          <td>{fund.Symbol}</td>
+          <td>{fund['Fund Name']}</td>
+          <td>-</td>
+          <td>{fmtPct(fund.ytd)}</td>
+          <td>{fmtPct(fund.oneYear)}</td>
+          <td>{fmtPct(fund.threeYear)}</td>
+          <td>{fmtPct(fund.fiveYear)}</td>
+          <td>{fmtNumber(fund.sharpe)}</td>
+          <td>{fmtPct(fund.stdDev5y)}</td>
+          <td>{fmtPct(fund.expense)}</td>
+        </tr>
+      </tbody>
+    </table>
+  );
+});

--- a/src/components/__tests__/__snapshots__/FundTable.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/FundTable.test.jsx.snap
@@ -97,22 +97,22 @@ exports[`renders table snapshot 1`] = `
           <td
             style="padding: 0.5rem; text-align: right;"
           >
-            2.00%
+            2.00 %
           </td>
           <td
             style="padding: 0.5rem; text-align: right;"
           >
-            10.00%
+            10.00 %
           </td>
           <td
             style="padding: 0.5rem; text-align: right;"
           >
-            12.00%
+            12.00 %
           </td>
           <td
             style="padding: 0.5rem; text-align: right;"
           >
-            15.00%
+            15.00 %
           </td>
           <td
             style="padding: 0.5rem; text-align: right;"
@@ -122,12 +122,12 @@ exports[`renders table snapshot 1`] = `
           <td
             style="padding: 0.5rem; text-align: right;"
           >
-            18.00%
+            18.00 %
           </td>
           <td
             style="padding: 0.5rem; text-align: right;"
           >
-            0.50%
+            0.50 %
           </td>
           <td
             style="padding: 0.5rem;"

--- a/src/services/__tests__/parseFundFile.normalization.test.js
+++ b/src/services/__tests__/parseFundFile.normalization.test.js
@@ -1,0 +1,13 @@
+import parseFundFile from '../parseFundFile';
+
+const mockRows = [
+  ['Symbol', 'Fund Name', 'YTD', '3 Year'],
+  ['AAA', 'Sample Fund', '10%', '5.5%'],
+];
+
+test('parseFundFile normalizes number fields', async () => {
+  const result = await parseFundFile(mockRows);
+  expect(result).toHaveLength(1);
+  const row = result[0];
+  expect(typeof row.threeYear === 'number' || row.threeYear === null).toBe(true);
+});

--- a/src/services/__tests__/parseMetrics.test.js
+++ b/src/services/__tests__/parseMetrics.test.js
@@ -12,6 +12,8 @@ test('BUYZ metrics parsed correctly', async () => {
   const result = await parseFundFile(rows, { recommendedFunds, assetClassBenchmarks });
   const buyz = result.find(r => r.Symbol === 'BUYZ');
   expect(buyz).toBeDefined();
+  expect(typeof buyz.ytd).toBe('number');
+  expect(buyz.ytd).toBeCloseTo(28.12, 2);
   expect(buyz['Net Expense Ratio']).toBeCloseTo(0.5);
   expect(typeof buyz['3 Year']).toBe('number');
 });

--- a/src/services/parseFundFile.js
+++ b/src/services/parseFundFile.js
@@ -54,6 +54,7 @@ export default async function parseFundFile(rows, options = {}) {
           key === 'Net Expense Ratio' ||
           key === 'Manager Tenure' ||
           key === 'Sharpe Ratio' ||
+          key === 'YTD' ||
           key.includes('Year') ||
           key.includes('Deviation')
         ) {
@@ -89,20 +90,35 @@ export default async function parseFundFile(rows, options = {}) {
 
     const assetClassFinal = assetClass || 'Unknown';
 
+    const ytd = cleanNumber(f['1 Year']);
+    const oneYear = cleanNumber(f['1 Year']);
+    const threeYear = cleanNumber(f['3 Year']);
+    const fiveYear = cleanNumber(f['5 Year']);
+    const sharpe = cleanNumber(f['Sharpe Ratio']);
+    const stdDev5y = cleanNumber(f['Standard Deviation']);
+    const expense = cleanNumber(f['Net Expense Ratio']);
+
     return {
       Symbol: f.Symbol,
       'Fund Name': f['Fund Name'],
       'Asset Class': assetClassFinal,
       assetClass: assetClassFinal,
-      YTD: f.YTD,
-      '1 Year': f['1 Year'],
-      '3 Year': f['3 Year'],
-      '5 Year': f['5 Year'],
-      'Sharpe Ratio': f['Sharpe Ratio'],
-      'Standard Deviation': f['Standard Deviation'],
-      'Net Expense Ratio': f['Net Expense Ratio'],
+      YTD: ytd,
+      '1 Year': oneYear,
+      '3 Year': threeYear,
+      '5 Year': fiveYear,
+      'Sharpe Ratio': sharpe,
+      'Standard Deviation': stdDev5y,
+      'Net Expense Ratio': expense,
       'Manager Tenure': f['Manager Tenure'],
       Type: f.type || '',
+      ytd,
+      oneYear,
+      threeYear,
+      fiveYear,
+      sharpe,
+      stdDev5y,
+      expense,
     };
   });
 }

--- a/src/utils/formatters.js
+++ b/src/utils/formatters.js
@@ -1,4 +1,9 @@
+export const fmtPct = (v, digits = 2) =>
+  v === null || isNaN(v) ? 'N/A' : `${Number(v).toFixed(digits)} %`;
+
+export const fmtNumber = v =>
+  v === null || isNaN(v) ? 'N/A' : Number(v).toFixed(2);
+
 export function formatPercent(value, digits = 2) {
-  if (value == null || isNaN(value)) return 'N/A';
-  return `${Number(value).toFixed(digits)}%`;
+  return fmtPct(value, digits);
 }


### PR DESCRIPTION
## Summary
- normalize numeric fields when parsing fund files
- add formatter helpers `fmtPct` and `fmtNumber`
- use helpers in FundTable, BenchmarkRow and Class View
- test parsing normalization and component rendering
- update existing snapshot
- add project changelog

## Testing
- `npm test -- --watchAll=false`
- `npm start` *(terminated after build)*

------
https://chatgpt.com/codex/tasks/task_e_6855ae9330d083299909e7bc20d21399