### PR TITLE
Fix benchmark retention after scoring

### DIFF
--- a/src/services/scoring.js
+++ b/src/services/scoring.js
@@ -299,8 +299,10 @@ const METRIC_WEIGHTS = {
         metrics: extractMetrics(fund)
       }));
       
-      // Calculate statistics for the asset class
-      const statistics = calculateMetricStatistics(fundsWithMetrics);
+      // Calculate statistics for the asset class using peer funds only
+      // Benchmarks should not affect the averages or standard deviations
+      const peerFunds = fundsWithMetrics.filter(f => !f.isBenchmark);
+      const statistics = calculateMetricStatistics(peerFunds);
       
       // Calculate raw scores for all funds
       const fundsWithRawScores = fundsWithMetrics.map(fund => {


### PR DESCRIPTION
## Summary
- ensure scoring stats ignore benchmark rows

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6855c06fc58c8329a8e53aa3dffebf50