### PR TITLE
Fix benchmark filter mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+- Unified asset class field across pipeline and filters; benchmarks now visible in Class View.
 - Normalize numeric fields when parsing fund files.
 - Added `fmtPct` and `fmtNumber` helpers and updated components to use them.
 - Added tests for parser normalization and Class View rendering.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -197,7 +197,7 @@ const App = () => {
         const summaries = {};
         const fundsByClass = {};
         taggedFunds.forEach(fund => {
-          const assetClass = fund['Asset Class'];
+          const assetClass = fund.assetClass;
           if (!fundsByClass[assetClass]) {
             fundsByClass[assetClass] = [];
           }
@@ -635,7 +635,7 @@ const App = () => {
               )}
               
               <ClassView
-                funds={scoredFundData.filter(f => f['Asset Class'] === selectedClassView)}
+                funds={scoredFundData.filter(f => f.assetClass === selectedClassView)}
               />
             </>
           )}
@@ -681,7 +681,7 @@ const App = () => {
                           {fund['Fund Name']}
                         </h3>
                         <p style={{ color: '#6b7280', fontSize: '0.875rem' }}>
-                          {fund.Symbol} | {fund['Asset Class']}
+                          {fund.Symbol} | {fund.assetClass}
                           {fund.isRecommended && (
                             <span style={{ 
                               marginLeft: '0.5rem',

--- a/src/components/Dashboard/AssetClassOverview.jsx
+++ b/src/components/Dashboard/AssetClassOverview.jsx
@@ -21,7 +21,7 @@ const AssetClassOverview = ({ funds, config }) => {
       .slice(-6)
       .map((snap) => {
         const rec = snap.funds.filter(
-          (f) => f.isRecommended && f['Asset Class'] === assetClass
+          (f) => f.isRecommended && f.assetClass === assetClass
         );
         const avg = rec.length
           ? Math.round(
@@ -40,7 +40,7 @@ const AssetClassOverview = ({ funds, config }) => {
   /* ---------- group funds by asset class ---------- */
   const byClass = {};
   inputFunds.forEach(f => {
-    const assetClass = f['Asset Class'] || 'Uncategorized';
+    const assetClass = f.assetClass || 'Uncategorized';
     if (!byClass[assetClass]) byClass[assetClass] = [];
     byClass[assetClass].push(f);
   });

--- a/src/components/Dashboard/PerformanceHeatmap.jsx
+++ b/src/components/Dashboard/PerformanceHeatmap.jsx
@@ -83,7 +83,7 @@ const PerformanceHeatmap = ({ funds }) => {
 
   const byClass = {};
   filtered.forEach(f => {
-    const assetClass = f['Asset Class'] || 'Uncategorized';
+    const assetClass = f.assetClass || 'Uncategorized';
     if (!byClass[assetClass]) byClass[assetClass] = [];
     byClass[assetClass].push(f);
   });

--- a/src/components/Dashboard/TopBottomPerformers.jsx
+++ b/src/components/Dashboard/TopBottomPerformers.jsx
@@ -40,7 +40,7 @@ const FundRow = ({ fund }) => (
   <tr style={{ borderBottom: '1px solid #f3f4f6' }}>
     <td style={{ padding: '0.5rem' }}>{fund['Fund Name']}</td>
     <td style={{ padding: '0.5rem' }}>{fund.Symbol}</td>
-    <td style={{ padding: '0.5rem' }}>{fund['Asset Class']}</td>
+    <td style={{ padding: '0.5rem' }}>{fund.assetClass}</td>
     <td style={{ padding: '0.5rem', textAlign: 'center' }}>
       <ScoreBadge score={fund.scores?.final || 0} />
     </td>

--- a/src/components/Modals/FundDetailsModal.jsx
+++ b/src/components/Modals/FundDetailsModal.jsx
@@ -22,7 +22,7 @@ const FundDetailsModal = ({ fund, onClose }) => {
           {fund.Symbol} – {fund['Fund Name']}
         </h3>
         <p style={{ marginBottom: '0.75rem', color: '#6b7280' }}>
-          Asset Class: {fund['Asset Class']} · Score:&nbsp;
+          Asset Class: {fund.assetClass} · Score:&nbsp;
           <span style={{ color: getScoreColor(fund.scores.final) }}>
             {fund.scores.final} ({getScoreLabel(fund.scores.final)})
           </span>

--- a/src/components/Trends/FundTimeline.jsx
+++ b/src/components/Trends/FundTimeline.jsx
@@ -28,11 +28,11 @@ const FundTimeline = ({ fundSymbol, dataSnapshots }) => {
 
   const chartData = sorted.map(snapshot => {
     const fund = snapshot.funds.find(f => (f.cleanSymbol || clean(f.Symbol)) === target);
-    const assetClass = fund?.['Asset Class'];
+    const assetClass = fund?.assetClass;
     let benchmarkScore = null;
     if (assetClass) {
       const benchmark = snapshot.funds.find(
-        f => f.isBenchmark && f['Asset Class'] === assetClass
+        f => f.isBenchmark && f.assetClass === assetClass
       );
       if (benchmark) benchmarkScore = benchmark.scores?.final ?? null;
     }

--- a/src/components/Views/FundScores.jsx
+++ b/src/components/Views/FundScores.jsx
@@ -21,7 +21,7 @@ const FundScores = () => {
   const [selectedFund, setSelectedFund] = useState(null);
 
   const filteredFunds = fundData.filter(f => {
-    const classMatch = selectedClass ? f['Asset Class'] === selectedClass : true;
+    const classMatch = selectedClass ? f.assetClass === selectedClass : true;
     const tagMatch = selectedTags.length > 0 ? selectedTags.every(t => f.tags?.includes(t)) : true;
     return classMatch && tagMatch;
   });

--- a/src/components/Views/FundView.jsx
+++ b/src/components/Views/FundView.jsx
@@ -29,7 +29,7 @@ const FundTable = ({ funds = [], onRowClick = () => {} }) => (
           >
             <td style={{ padding: '0.5rem' }}>{fund.Symbol}</td>
             <td style={{ padding: '0.5rem' }}>{fund['Fund Name']}</td>
-            <td style={{ padding: '0.5rem' }}>{fund['Asset Class']}</td>
+            <td style={{ padding: '0.5rem' }}>{fund.assetClass}</td>
             <td style={{ padding: '0.5rem', textAlign: 'center' }}>
               {fund.scores ? (
                 <span
@@ -79,7 +79,7 @@ const FundView = () => {
 
   /* apply filters */
   const filteredFunds = fundData.filter(f => {
-    const classMatch = selectedClass ? f['Asset Class'] === selectedClass : true;
+    const classMatch = selectedClass ? f.assetClass === selectedClass : true;
     const tagMatch   =
       selectedTags.length > 0
         ? selectedTags.every(tag => Array.isArray(f.tags) && f.tags.includes(tag))

--- a/src/components/__tests__/ClassView.integration.test.jsx
+++ b/src/components/__tests__/ClassView.integration.test.jsx
@@ -54,7 +54,7 @@ test('benchmark row and summary rendered', async () => {
   });
   const withBench = ensureBenchmarkRows(withFlags);
   const scored = calculateScores(withBench);
-  const funds = scored.filter(f => f['Asset Class'] === 'Large Cap Growth');
+  const funds = scored.filter(f => f.assetClass === 'Large Cap Growth');
   render(<ClassView funds={funds} />);
   expect(screen.getByText('IWF')).toBeInTheDocument();
   expect(screen.getByTestId('summary').textContent).not.toBe('N/A');

--- a/src/services/__tests__/mapping.test.js
+++ b/src/services/__tests__/mapping.test.js
@@ -15,10 +15,10 @@ describe('asset class mapping', () => {
 
   test('getAssetClassOptions returns classes', () => {
     const data = [
-      { 'Asset Class': 'Large Cap Growth' },
-      { 'Asset Class': 'Large Cap Value' },
-      { 'Asset Class': 'Large Cap Growth' },
-      { 'Asset Class': 'Benchmark' }
+      { assetClass: 'Large Cap Growth' },
+      { assetClass: 'Large Cap Value' },
+      { assetClass: 'Large Cap Growth' },
+      { assetClass: 'Benchmark' }
     ];
     const opts = getAssetClassOptions(data);
     expect(Array.isArray(opts)).toBe(true);

--- a/src/services/__tests__/scoringPerClass.test.js
+++ b/src/services/__tests__/scoringPerClass.test.js
@@ -6,7 +6,7 @@ describe('per-class scoring with benchmark integration', () => {
       {
         Symbol: 'AAA',
         'Fund Name': 'Fund A',
-        'Asset Class': 'Large Cap Growth',
+        assetClass: 'Large Cap Growth',
         '1 Year': 12,
         '3 Year': 14,
         '5 Year': 16,
@@ -18,7 +18,7 @@ describe('per-class scoring with benchmark integration', () => {
       {
         Symbol: 'BBB',
         'Fund Name': 'Fund B',
-        'Asset Class': 'Large Cap Growth',
+        assetClass: 'Large Cap Growth',
         '1 Year': 8,
         '3 Year': 9,
         '5 Year': 10,
@@ -30,7 +30,7 @@ describe('per-class scoring with benchmark integration', () => {
       {
         Symbol: 'IWF',
         'Fund Name': 'Russell 1000 Growth',
-        'Asset Class': 'Large Cap Growth',
+        assetClass: 'Large Cap Growth',
         '1 Year': 10,
         '3 Year': 11,
         '5 Year': 12,

--- a/src/services/dataLoader.js
+++ b/src/services/dataLoader.js
@@ -85,8 +85,8 @@ export function ensureBenchmarkRows(list = []) {
         symbol: ticker,
         'Fund Name': name,
         name,
-        'Asset Class': assetClass,
         assetClass,
+        'Asset Class': assetClass,
         isBenchmark: true,
         benchmarkForClass: assetClass,
         ytd: null,
@@ -101,6 +101,8 @@ export function ensureBenchmarkRows(list = []) {
       const row = map.get(key);
       row.isBenchmark = true;
       if (!row.benchmarkForClass) row.benchmarkForClass = assetClass;
+      if (!row.assetClass) row.assetClass = row['Asset Class'] || assetClass;
+      row['Asset Class'] = row.assetClass;
     }
   });
   return list;

--- a/src/services/dataStore.js
+++ b/src/services/dataStore.js
@@ -450,7 +450,7 @@ export async function compareSnapshots(snapshotId1, snapshotId2) {
         comparison.changes.push({
           symbol,
           fundName: fund2['Fund Name'],
-          assetClass: fund2['Asset Class'],
+          assetClass: fund2.assetClass,
           oldScore: fund1.scores.final,
           newScore: fund2.scores.final,
           change: scoreDiff,
@@ -462,7 +462,7 @@ export async function compareSnapshots(snapshotId1, snapshotId2) {
       comparison.changes.push({
         symbol,
         fundName: fund2['Fund Name'],
-        assetClass: fund2['Asset Class'],
+        assetClass: fund2.assetClass,
         type: 'new',
         newScore: fund2.scores?.final
       });
@@ -475,7 +475,7 @@ export async function compareSnapshots(snapshotId1, snapshotId2) {
       comparison.changes.push({
         symbol,
         fundName: fund1['Fund Name'],
-        assetClass: fund1['Asset Class'],
+        assetClass: fund1.assetClass,
         type: 'removed',
         oldScore: fund1.scores?.final
       });

--- a/src/services/parseFundFile.js
+++ b/src/services/parseFundFile.js
@@ -106,11 +106,11 @@ export default async function parseFundFile(rows, options = {}) {
     const stdDev5y = cleanNumber(f['Standard Deviation']);
     const expense = cleanNumber(f['Net Expense Ratio']);
 
-    return {
+    const row = {
       Symbol: f.Symbol,
       'Fund Name': f['Fund Name'],
-      'Asset Class': assetClassFinal,
       assetClass: assetClassFinal,
+      'Asset Class': assetClassFinal,
       YTD: ytd,
       '1 Year': oneYear,
       '3 Year': threeYear,
@@ -128,5 +128,8 @@ export default async function parseFundFile(rows, options = {}) {
       stdDev5y,
       expense,
     };
+    // keep header-style copy for legacy filters/exports
+    row['Asset Class'] = row.assetClass;
+    return row;
   });
 }

--- a/src/services/scoring.js
+++ b/src/services/scoring.js
@@ -261,7 +261,7 @@ const METRIC_WEIGHTS = {
     // Group funds by asset class and ignore rows explicitly marked as Benchmark
     const fundsByClass = {};
     funds.forEach(fund => {
-      const assetClass = fund['Asset Class'] || 'Unknown';
+      const assetClass = fund.assetClass || fund['Asset Class'] || 'Unknown';
       if (assetClass === 'Benchmark') return;
       if (!fundsByClass[assetClass]) {
         fundsByClass[assetClass] = [];

--- a/src/services/tagEngine.js
+++ b/src/services/tagEngine.js
@@ -13,7 +13,7 @@ export function applyTagRules(funds, config = {}) {
   const stdAvgByClass = {};
 
   funds.forEach(fund => {
-    const assetClass = fund['Asset Class'] || fund.assetClass || 'Unknown';
+    const assetClass = fund.assetClass || fund['Asset Class'] || 'Unknown';
     if (!expenseAvgByClass[assetClass]) expenseAvgByClass[assetClass] = [];
     if (!stdAvgByClass[assetClass]) stdAvgByClass[assetClass] = [];
 
@@ -39,7 +39,7 @@ export function applyTagRules(funds, config = {}) {
   const benchmarkSharpe = {};
   funds.forEach(fund => {
     if (fund.isBenchmark) {
-      const assetClass = fund['Asset Class'] || fund.assetClass || 'Unknown';
+      const assetClass = fund.assetClass || fund['Asset Class'] || 'Unknown';
       const sharpe = fund.metrics?.sharpeRatio3Y;
       if (sharpe != null && !isNaN(sharpe)) {
         benchmarkSharpe[assetClass] = sharpe;
@@ -48,7 +48,7 @@ export function applyTagRules(funds, config = {}) {
   });
 
   return funds.map(fund => {
-    const assetClass = fund['Asset Class'] || fund.assetClass || 'Unknown';
+    const assetClass = fund.assetClass || fund['Asset Class'] || 'Unknown';
     const tags = new Set(Array.isArray(fund.tags) ? fund.tags : []);
 
     const score = fund.scores?.final;


### PR DESCRIPTION
## Summary
- sync `assetClass` and header field when parsing and injecting benchmarks
- use `assetClass` in all filters and searches
- adjust tests for new field usage
- ensure stub benchmarks copy both field names
- update changelog

## Testing
- `npm test -- --watchAll=false`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6855f00f6ebc8329b58407ab5f887c8a