### PR TITLE
Fix benchmark row filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,4 @@
 - Inject benchmark rows for each asset class when missing.
 - Added ensureBenchmarkRows helper with console logs and ClassView component.
 - BenchmarkRow banner table ensures benchmark row visible in ClassView; added ClassView.css and tests.
+- Benchmarks preserved during scoring; debug log shows benchmark count.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -259,6 +259,13 @@ const App = () => {
         setFundData(taggedFunds);
         setScoredFundData(taggedFunds);
         setClassSummaries(summaries);
+        console.debug(
+          '[DEBUG] scoredFundData',
+          'total:',
+          taggedFunds.length,
+          'benchmarks:',
+          taggedFunds.filter(f => f.isBenchmark).length
+        );
         console.log('Successfully loaded and scored', taggedFunds.length, 'funds');
       } catch (err) {
         console.error('Error parsing performance file:', err);

--- a/src/services/__tests__/scoringPerClass.test.js
+++ b/src/services/__tests__/scoringPerClass.test.js
@@ -45,6 +45,7 @@ describe('per-class scoring with benchmark integration', () => {
     const summary = generateClassSummary(scored);
     const benchmark = scored.find(f => f.isBenchmark);
 
+    expect(scored.filter(r => r.isBenchmark).length).toBeGreaterThan(0);
     expect(typeof benchmark.scores.final).toBe('number');
     expect(summary.benchmarkScore).toBeCloseTo(benchmark.scores.final);
     expect(summary.fundCount).toBe(2); // peers only

--- a/src/services/scoring.js
+++ b/src/services/scoring.js
@@ -262,7 +262,6 @@ const METRIC_WEIGHTS = {
     const fundsByClass = {};
     funds.forEach(fund => {
       const assetClass = fund.assetClass || fund['Asset Class'] || 'Unknown';
-      if (assetClass === 'Benchmark') return;
       if (!fundsByClass[assetClass]) {
         fundsByClass[assetClass] = [];
       }


### PR DESCRIPTION
## Summary
- keep benchmark rows when grouping for scoring
- output debug info with benchmark count when processing files
- assert benchmark rows exist in scoring tests
- update changelog

## Testing
- `npm test -- --watchAll=false`
- `npm start` *(started dev server)*

------
https://chatgpt.com/codex/tasks/task_e_6856212053288329a269af28a9447959