### PR TITLE
Show benchmark data across all views

### DIFF
--- a/src/components/Dashboard/AssetClassOverview.jsx
+++ b/src/components/Dashboard/AssetClassOverview.jsx
@@ -60,6 +60,8 @@ const AssetClassOverview = ({ funds, config }) => {
     const avgStd     = stdVals.length     ? (stdVals.reduce((s, v)     => s + v, 0) / stdVals.length    ).toFixed(2) : null;
 
     const benchmarkTicker = config?.[assetClass]?.ticker || '-';
+    const benchmarkFund   = classFunds.find(f => f.isBenchmark);
+    const benchmarkScore  = benchmarkFund?.scores?.final ?? null;
     const scoreCol        = scoreColor(avgScore);
 
     const tags = Array.from(
@@ -76,6 +78,7 @@ const AssetClassOverview = ({ funds, config }) => {
       avgExpense,
       avgStd,
       benchmarkTicker,
+      benchmarkScore,
       color: scoreCol,
       tags,
       trend: trendPoints
@@ -156,6 +159,11 @@ const AssetClassOverview = ({ funds, config }) => {
 
             <div style={{ fontSize: '0.75rem', color: '#6b7280', marginTop: '0.25rem' }}>
               Benchmark: {info.benchmarkTicker}
+              {info.benchmarkScore != null && (
+                <span style={{ marginLeft: '0.25rem', color: info.color }}>
+                  ({info.benchmarkScore})
+                </span>
+              )}
             </div>
 
             {info.tags.length > 0 && (

--- a/src/components/Dashboard/PerformanceHeatmap.jsx
+++ b/src/components/Dashboard/PerformanceHeatmap.jsx
@@ -74,15 +74,13 @@ const PerformanceHeatmap = ({ funds }) => {
     return null;
   }
 
-  const filtered = funds.filter(
-    f => f.isRecommended && !f.isBenchmark
-  );
-  if (filtered.length === 0) {
+  const peers = funds.filter(f => f.isRecommended && !f.isBenchmark);
+  if (peers.length === 0) {
     return null;
   }
 
   const byClass = {};
-  filtered.forEach(f => {
+  peers.forEach(f => {
     const assetClass = f.assetClass || 'Uncategorized';
     if (!byClass[assetClass]) byClass[assetClass] = [];
     byClass[assetClass].push(f);
@@ -91,6 +89,8 @@ const PerformanceHeatmap = ({ funds }) => {
   Object.values(byClass).forEach(list => {
     list.sort((a, b) => (b.scores?.final || 0) - (a.scores?.final || 0));
   });
+
+  const benchmarks = funds.filter(f => f.isBenchmark);
 
   return (
     <div style={{ marginBottom: '1.5rem' }}>
@@ -107,22 +107,26 @@ const PerformanceHeatmap = ({ funds }) => {
         <LayoutGrid size={18} /> Performance Heatmap
       </h3>
 
-      {Object.entries(byClass).map(([assetClass, classFunds]) => (
-        <div key={assetClass} style={{ marginBottom: '1rem' }}>
-          <h4 style={{ fontWeight: 'bold', marginBottom: '0.25rem' }}>{assetClass}</h4>
-          <div
-            style={{
-              display: 'grid',
-              gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))',
-              gap: '0.5rem'
-            }}
-          >
-            {classFunds.map(fund => (
-              <FundTile key={fund.Symbol} fund={fund} />
-            ))}
+      {Object.entries(byClass).map(([assetClass, classFunds]) => {
+        const benchmark = benchmarks.find(b => b.assetClass === assetClass);
+        return (
+          <div key={assetClass} style={{ marginBottom: '1rem' }}>
+            <h4 style={{ fontWeight: 'bold', marginBottom: '0.25rem' }}>{assetClass}</h4>
+            <div
+              style={{
+                display: 'grid',
+                gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))',
+                gap: '0.5rem'
+              }}
+            >
+              {benchmark && <FundTile key={benchmark.Symbol} fund={benchmark} />}
+              {classFunds.map(fund => (
+                <FundTile key={fund.Symbol} fund={fund} />
+              ))}
+            </div>
           </div>
-        </div>
-      ))}
+        );
+      })}
     </div>
   );
 };

--- a/src/components/FundTable.jsx
+++ b/src/components/FundTable.jsx
@@ -34,6 +34,7 @@ const FundTable = ({ funds = [], rows, onRowClick = () => {} }) => {
         <tr style={{ borderBottom: '2px solid #e5e7eb' }}>
           <th style={{ padding: '0.75rem', textAlign: 'left' }}>Symbol</th>
           <th style={{ padding: '0.75rem', textAlign: 'left' }}>Fund Name</th>
+          <th style={{ padding: '0.75rem', textAlign: 'left' }}>Type</th>
           <th style={{ padding: '0.75rem', textAlign: 'center' }}>Score</th>
           <th style={{ padding: '0.75rem', textAlign: 'right' }}>YTD</th>
           <th style={{ padding: '0.75rem', textAlign: 'right' }}>1Y</th>
@@ -49,7 +50,11 @@ const FundTable = ({ funds = [], rows, onRowClick = () => {} }) => {
         {data.map(fund => (
           <tr
             key={fund.Symbol}
-            style={{ borderBottom: '1px solid #f3f4f6', cursor: 'pointer' }}
+            style={{
+              borderBottom: '1px solid #f3f4f6',
+              cursor: 'pointer',
+              backgroundColor: fund.isBenchmark ? '#fffbeb' : 'transparent'
+            }}
             role="button"
             tabIndex={0}
             onKeyDown={e => e.key === 'Enter' && onRowClick(fund)}
@@ -57,6 +62,9 @@ const FundTable = ({ funds = [], rows, onRowClick = () => {} }) => {
           >
             <td style={{ padding: '0.5rem' }}>{fund.Symbol}</td>
             <td style={{ padding: '0.5rem' }}>{fund['Fund Name']}</td>
+            <td style={{ padding: '0.5rem' }}>
+              {fund.isBenchmark ? 'Benchmark' : fund.isRecommended ? 'Recommended' : ''}
+            </td>
             <td style={{ padding: '0.5rem', textAlign: 'center' }}>
               {fund.scores ? <ScoreBadge score={fund.scores.final} /> : '-'}
             </td>

--- a/src/components/Views/FundScores.jsx
+++ b/src/components/Views/FundScores.jsx
@@ -4,7 +4,7 @@ import { Download } from 'lucide-react';
 import { exportToExcel } from '../../services/exportService';
 import AppContext from '../../context/AppContext.jsx';
 import FundDetailsModal from '../Modals/FundDetailsModal.jsx';
-import FundTable from '../FundTable.jsx';
+import ClassView from '../ClassView.jsx';
 
 const FundScores = () => {
   const {
@@ -30,6 +30,13 @@ const FundScores = () => {
     if (filteredFunds.length === 0) return;
     exportToExcel(filteredFunds);
   };
+
+  const byClass = {};
+  filteredFunds.forEach(f => {
+    const cls = f.assetClass || 'Uncategorized';
+    if (!byClass[cls]) byClass[cls] = [];
+    byClass[cls].push(f);
+  });
 
   return (
     <div>
@@ -64,7 +71,12 @@ const FundScores = () => {
       {filteredFunds.length === 0 ? (
         <p style={{ color: '#6b7280' }}>No funds match your current filter selection.</p>
       ) : (
-        <FundTable funds={filteredFunds} onRowClick={setSelectedFund} />
+        Object.entries(byClass).map(([cls, funds]) => (
+          <div key={cls} style={{ marginBottom: '2rem' }}>
+            <h3 style={{ fontWeight: 'bold', marginBottom: '0.5rem' }}>{cls}</h3>
+            <ClassView funds={funds} />
+          </div>
+        ))
       )}
 
       {selectedFund && (

--- a/src/components/__tests__/__snapshots__/FundTable.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/FundTable.test.jsx.snap
@@ -23,6 +23,11 @@ exports[`renders table snapshot 1`] = `
             Fund Name
           </th>
           <th
+            style="padding: 0.75rem; text-align: left;"
+          >
+            Type
+          </th>
+          <th
             style="padding: 0.75rem; text-align: center;"
           >
             Score
@@ -72,7 +77,7 @@ exports[`renders table snapshot 1`] = `
       <tbody>
         <tr
           role="button"
-          style="border-bottom: 1px solid #f3f4f6; cursor: pointer;"
+          style="border-bottom: 1px solid #f3f4f6; cursor: pointer; background-color: transparent;"
           tabindex="0"
         >
           <td
@@ -85,6 +90,9 @@ exports[`renders table snapshot 1`] = `
           >
             Alpha Fund
           </td>
+          <td
+            style="padding: 0.5rem;"
+          />
           <td
             style="padding: 0.5rem; text-align: center;"
           >


### PR DESCRIPTION
## Summary
- highlight benchmark rows in `FundTable`
- show benchmark score in `AssetClassOverview`
- display benchmarks in the heatmap grid
- reorganize Fund Scores view by asset class
- update snapshot

## Testing
- `npm test --silent -- -u`

------
https://chatgpt.com/codex/tasks/task_e_6856234624e48329b33946ebf739aa76