### PR TITLE
Fix benchmark asset class handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 - Unified asset class field across pipeline and filters; benchmarks now visible in Class View.
+- Preserve correct assetClass when flagging benchmark rows; Class View filters now match benchmarks.
 - Benchmark row now rendered above the fund table in Class View.
 - Normalize numeric fields when parsing fund files.
 - Added `fmtPct` and `fmtNumber` helpers and updated components to use them.

--- a/src/services/__tests__/ensureBenchmarkRows.test.js
+++ b/src/services/__tests__/ensureBenchmarkRows.test.js
@@ -5,3 +5,19 @@ test('ensureBenchmarkRows adds benchmarks when list empty', () => {
   expect(result.length).toBeGreaterThan(0);
   expect(result[0].isBenchmark).toBe(true);
 });
+
+test('existing benchmark row retains its asset class', () => {
+  const list = [
+    {
+      symbol: 'IWF',
+      name: 'iShares Russell 1000 Growth',
+      assetClass: 'Large Cap Growth',
+      'Asset Class': 'Large Cap Growth',
+    },
+  ];
+  const result = ensureBenchmarkRows(list);
+  const fund = result.find(r => r.symbol === 'IWF');
+  expect(fund.assetClass).toBe('Large Cap Growth');
+  expect(fund['Asset Class']).toBe('Large Cap Growth');
+  expect(fund.isBenchmark).toBe(true);
+});

--- a/src/services/dataLoader.js
+++ b/src/services/dataLoader.js
@@ -101,8 +101,14 @@ export function ensureBenchmarkRows(list = []) {
       const row = map.get(key);
       row.isBenchmark = true;
       if (!row.benchmarkForClass) row.benchmarkForClass = assetClass;
-      if (!row.assetClass) row.assetClass = row['Asset Class'] || assetClass;
-      row['Asset Class'] = row.assetClass;
+      const existingClass = row.assetClass || row['Asset Class'];
+      if (!existingClass || existingClass === 'Benchmark') {
+        row.assetClass = assetClass;
+        row['Asset Class'] = assetClass;
+      } else {
+        row.assetClass = existingClass;
+        row['Asset Class'] = existingClass;
+      }
     }
   });
   return list;


### PR DESCRIPTION
## Summary
- ensureBenchmarkRows keeps original asset class when marking benchmark rows
- add unit test covering benchmark asset class preservation
- update changelog

## Testing
- `npm test -- --watchAll=false`
- `npm run audit:benchmarks`


------
https://chatgpt.com/codex/tasks/task_e_68595068a5c88329930f21a934dae616