### PR TITLE
Add grouped view and UI polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,4 @@
 - BenchmarkRow banner table ensures benchmark row visible in ClassView; added ClassView.css and tests.
 - Benchmarks preserved during scoring; debug log shows benchmark count.
 - Added benchmark audit script and flow documentation; dashboard views show benchmarks by default.
+- Grouped fund scores view with accordion sections and toggle; UI polish on tables and dashboard grid.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -601,22 +601,31 @@ const App = () => {
             Asset Class Comparison
           </h2>
           
-          <select
-            value={selectedClassView}
-            onChange={e => setSelectedClassView(e.target.value)}
-            style={{ 
-              padding: '0.5rem', 
-              marginBottom: '1rem',
-              border: '1px solid #d1d5db',
-              borderRadius: '0.375rem',
-              fontSize: '1rem'
+          <div
+            style={{
+              position: 'sticky',
+              top: 0,
+              zIndex: 10,
+              background: 'white'
             }}
           >
-            <option value="">-- Choose an asset class --</option>
-            {availableClasses.map(ac => (
-              <option key={ac} value={ac}>{ac}</option>
-            ))}
-          </select>
+            <select
+              value={selectedClassView}
+              onChange={e => setSelectedClassView(e.target.value)}
+              style={{
+                padding: '0.5rem',
+                marginBottom: '1rem',
+                border: '1px solid #d1d5db',
+                borderRadius: '0.375rem',
+                fontSize: '1rem'
+              }}
+            >
+              <option value="">-- Choose an asset class --</option>
+              {availableClasses.map(ac => (
+                <option key={ac} value={ac}>{ac}</option>
+              ))}
+            </select>
+          </div>
           
           {selectedClassView && (
             <>

--- a/src/components/BenchmarkRow.jsx
+++ b/src/components/BenchmarkRow.jsx
@@ -13,6 +13,7 @@ const ScoreBadge = ({ score }) => {
         border: `1px solid ${color}50`,
         borderRadius: '9999px',
         fontSize: '0.75rem',
+        fontWeight: 'bold',
         padding: '0.25rem 0.5rem',
         display: 'inline-block',
         minWidth: '3rem',

--- a/src/components/ClassView.css
+++ b/src/components/ClassView.css
@@ -1,5 +1,8 @@
 .benchmark-banner {
-  background: #f4f4f4;
-  font-weight: 600;
+  background: #f1f5f9; /* slate-100 */
+  border-radius: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  margin-bottom: 0.25rem;
+  font-weight: 500;
 }
 

--- a/src/components/Dashboard/AssetClassOverview.css
+++ b/src/components/Dashboard/AssetClassOverview.css
@@ -1,0 +1,10 @@
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1rem;
+}
+@media (min-width: 768px) {
+  .dashboard-grid {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}

--- a/src/components/Dashboard/AssetClassOverview.jsx
+++ b/src/components/Dashboard/AssetClassOverview.jsx
@@ -4,6 +4,7 @@ import { Layers } from 'lucide-react';
 import TagList from '../TagList.jsx';
 import { LineChart, Line } from 'recharts';
 import AppContext from '../../context/AppContext.jsx';
+import './AssetClassOverview.css';
 
 /**
  * Show summary cards for each asset class.
@@ -101,13 +102,7 @@ const AssetClassOverview = ({ funds, config }) => {
         <Layers size={18} /> Asset Class Overview
       </h3>
 
-      <div
-        style={{
-          display: 'grid',
-          gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))',
-          gap: '1rem'
-        }}
-      >
+      <div className="dashboard-grid">
         {classInfo.map(info => (
           <div
             key={info.assetClass}

--- a/src/components/FundTable.jsx
+++ b/src/components/FundTable.jsx
@@ -14,6 +14,7 @@ const ScoreBadge = ({ score }) => {
         border: `1px solid ${color}50`,
         borderRadius: '9999px',
         fontSize: '0.75rem',
+        fontWeight: 'bold',
         padding: '0.25rem 0.5rem',
         display: 'inline-block',
         minWidth: '3rem',
@@ -32,18 +33,18 @@ const FundTable = ({ funds = [], rows, onRowClick = () => {} }) => {
       <table style={{ width: '100%', borderCollapse: 'collapse' }}>
       <thead>
         <tr style={{ borderBottom: '2px solid #e5e7eb' }}>
-          <th style={{ padding: '0.75rem', textAlign: 'left' }}>Symbol</th>
-          <th style={{ padding: '0.75rem', textAlign: 'left' }}>Fund Name</th>
-          <th style={{ padding: '0.75rem', textAlign: 'left' }}>Type</th>
-          <th style={{ padding: '0.75rem', textAlign: 'center' }}>Score</th>
-          <th style={{ padding: '0.75rem', textAlign: 'right' }}>YTD</th>
-          <th style={{ padding: '0.75rem', textAlign: 'right' }}>1Y</th>
-          <th style={{ padding: '0.75rem', textAlign: 'right' }}>3Y</th>
-          <th style={{ padding: '0.75rem', textAlign: 'right' }}>5Y</th>
-          <th style={{ padding: '0.75rem', textAlign: 'right' }}>Sharpe</th>
-          <th style={{ padding: '0.75rem', textAlign: 'right' }}>Std Dev (5Y)</th>
-          <th style={{ padding: '0.75rem', textAlign: 'right' }}>Expense</th>
-          <th style={{ padding: '0.75rem', textAlign: 'left' }}>Tags</th>
+          <th style={{ padding: '0.75rem', textAlign: 'left', fontWeight: 500 }}>Symbol</th>
+          <th style={{ padding: '0.75rem', textAlign: 'left', fontWeight: 500 }}>Fund Name</th>
+          <th style={{ padding: '0.75rem', textAlign: 'left', fontWeight: 500 }}>Type</th>
+          <th style={{ padding: '0.75rem', textAlign: 'center', fontWeight: 500 }}>Score</th>
+          <th style={{ padding: '0.75rem', textAlign: 'right', fontWeight: 500 }}>YTD</th>
+          <th style={{ padding: '0.75rem', textAlign: 'right', fontWeight: 500 }}>1Y</th>
+          <th style={{ padding: '0.75rem', textAlign: 'right', fontWeight: 500 }}>3Y</th>
+          <th style={{ padding: '0.75rem', textAlign: 'right', fontWeight: 500 }}>5Y</th>
+          <th style={{ padding: '0.75rem', textAlign: 'right', fontWeight: 500 }}>Sharpe</th>
+          <th style={{ padding: '0.75rem', textAlign: 'right', fontWeight: 500 }}>Std Dev (5Y)</th>
+          <th style={{ padding: '0.75rem', textAlign: 'right', fontWeight: 500 }}>Expense</th>
+          <th style={{ padding: '0.75rem', textAlign: 'left', fontWeight: 500 }}>Tags</th>
         </tr>
       </thead>
       <tbody>

--- a/src/components/GroupedFundTable.jsx
+++ b/src/components/GroupedFundTable.jsx
@@ -1,0 +1,65 @@
+import React, { useState } from 'react';
+import BenchmarkRow from './BenchmarkRow.jsx';
+import FundTable from './FundTable.jsx';
+
+/**
+ * Group funds by asset class and render expandable sections.
+ * @param {Array<Object>} funds
+ * @param {Function} onRowClick
+ */
+const GroupedFundTable = ({ funds = [], onRowClick = () => {} }) => {
+  const groups = {};
+  funds.forEach(f => {
+    const cls = f.assetClass || 'Uncategorized';
+    if (!groups[cls]) groups[cls] = [];
+    groups[cls].push(f);
+  });
+
+  const [open, setOpen] = useState({});
+  const toggle = cls =>
+    setOpen(prev => ({ ...prev, [cls]: !prev[cls] }));
+
+  return (
+    <div>
+      {Object.entries(groups).map(([cls, rows]) => {
+        const benchmark = rows.find(r => r.isBenchmark);
+        const peers = rows.filter(r => !r.isBenchmark);
+        const avg = peers.length
+          ? Math.round(
+              peers.reduce((s, f) => s + (f.scores?.final || 0), 0) / peers.length
+            )
+          : 0;
+        const benchScore = benchmark?.scores?.final;
+        return (
+          <div key={cls} style={{ marginBottom: '1rem' }}>
+            <div
+              onClick={() => toggle(cls)}
+              style={{
+                cursor: 'pointer',
+                fontWeight: '500',
+                display: 'flex',
+                justifyContent: 'space-between',
+                padding: '0.5rem 0',
+                borderBottom: '1px solid #e5e7eb'
+              }}
+            >
+              <span>{cls}</span>
+              <span>
+                Avg {avg}
+                {benchScore != null && ` | Benchmark ${benchScore}`}
+              </span>
+            </div>
+            {open[cls] && (
+              <div style={{ marginTop: '0.5rem' }}>
+                {benchmark && <BenchmarkRow fund={benchmark} />}
+                <FundTable rows={peers} onRowClick={onRowClick} />
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default GroupedFundTable;

--- a/src/components/Views/FundScores.jsx
+++ b/src/components/Views/FundScores.jsx
@@ -4,7 +4,8 @@ import { Download } from 'lucide-react';
 import { exportToExcel } from '../../services/exportService';
 import AppContext from '../../context/AppContext.jsx';
 import FundDetailsModal from '../Modals/FundDetailsModal.jsx';
-import ClassView from '../ClassView.jsx';
+import FundTable from '../FundTable.jsx';
+import GroupedFundTable from '../GroupedFundTable.jsx';
 
 const FundScores = () => {
   const {
@@ -31,12 +32,15 @@ const FundScores = () => {
     exportToExcel(filteredFunds);
   };
 
-  const byClass = {};
-  filteredFunds.forEach(f => {
-    const cls = f.assetClass || 'Uncategorized';
-    if (!byClass[cls]) byClass[cls] = [];
-    byClass[cls].push(f);
-  });
+  const [grouped, setGrouped] = useState(
+    () => localStorage.getItem('ls_grouped_view') === 'true'
+  );
+
+  const toggleView = () => {
+    const next = !grouped;
+    setGrouped(next);
+    localStorage.setItem('ls_grouped_view', String(next));
+  };
 
   return (
     <div>
@@ -49,7 +53,7 @@ const FundScores = () => {
         onTagToggle={toggleTag}
         onReset={resetFilters}
       />
-      <div style={{ marginBottom: '1rem' }}>
+      <div style={{ marginBottom: '1rem', display: 'flex', gap: '0.5rem' }}>
         <button
           onClick={handleExport}
           style={{
@@ -67,16 +71,25 @@ const FundScores = () => {
           <Download size={16} />
           Export to Excel
         </button>
+        <button
+          onClick={toggleView}
+          style={{
+            padding: '0.5rem 1rem',
+            backgroundColor: '#e5e7eb',
+            border: '1px solid #d1d5db',
+            borderRadius: '0.375rem',
+            cursor: 'pointer'
+          }}
+        >
+          {grouped ? 'Flat' : 'Grouped'} View
+        </button>
       </div>
       {filteredFunds.length === 0 ? (
         <p style={{ color: '#6b7280' }}>No funds match your current filter selection.</p>
+      ) : grouped ? (
+        <GroupedFundTable funds={filteredFunds} onRowClick={setSelectedFund} />
       ) : (
-        Object.entries(byClass).map(([cls, funds]) => (
-          <div key={cls} style={{ marginBottom: '2rem' }}>
-            <h3 style={{ fontWeight: 'bold', marginBottom: '0.5rem' }}>{cls}</h3>
-            <ClassView funds={funds} />
-          </div>
-        ))
+        <FundTable funds={filteredFunds} onRowClick={setSelectedFund} />
       )}
 
       {selectedFund && (

--- a/src/components/__tests__/GroupedFundTable.integration.test.jsx
+++ b/src/components/__tests__/GroupedFundTable.integration.test.jsx
@@ -1,0 +1,45 @@
+import fs from 'fs';
+import path from 'path';
+import * as XLSX from 'xlsx';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import GroupedFundTable from '../GroupedFundTable.jsx';
+import parseFundFile from '../../services/parseFundFile';
+import { recommendedFunds, assetClassBenchmarks } from '../../data/config';
+import { calculateScores } from '../../services/scoring';
+import { ensureBenchmarkRows } from '../../services/dataLoader';
+
+const clean = s => s?.toUpperCase().trim().replace(/[^A-Z0-9]/g, '');
+
+async function loadFunds() {
+  const csvPath = path.resolve(__dirname, '../../../data/Fund_Performance_Data.csv');
+  const csv = fs.readFileSync(csvPath, 'utf8');
+  const wb = XLSX.read(csv, { type: 'string' });
+  const rows = XLSX.utils.sheet_to_json(wb.Sheets[wb.SheetNames[0]], { header: 1 });
+  const parsed = await parseFundFile(rows, { recommendedFunds, assetClassBenchmarks });
+  const withFlags = parsed.map(f => {
+    const sym = clean(f.Symbol);
+    let benchmarkForClass = null;
+    Object.entries(assetClassBenchmarks).forEach(([ac, b]) => {
+      if (clean(b.ticker) === sym) benchmarkForClass = ac;
+    });
+    return {
+      ...f,
+      cleanSymbol: sym,
+      isBenchmark: benchmarkForClass != null,
+      benchmarkForClass,
+    };
+  });
+  const withBench = ensureBenchmarkRows(withFlags);
+  return calculateScores(withBench);
+}
+
+test('accordion expands to show benchmark row', async () => {
+  const funds = await loadFunds();
+  render(<GroupedFundTable funds={funds} />);
+  const header = screen.getByText('Large Cap Growth');
+  expect(header).toBeInTheDocument();
+  await userEvent.click(header);
+  expect(await screen.findByText(/Benchmark — IWF/i)).toBeInTheDocument();
+});

--- a/src/components/__tests__/__snapshots__/FundTable.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/FundTable.test.jsx.snap
@@ -13,62 +13,62 @@ exports[`renders table snapshot 1`] = `
           style="border-bottom: 2px solid #e5e7eb;"
         >
           <th
-            style="padding: 0.75rem; text-align: left;"
+            style="padding: 0.75rem; text-align: left; font-weight: 500;"
           >
             Symbol
           </th>
           <th
-            style="padding: 0.75rem; text-align: left;"
+            style="padding: 0.75rem; text-align: left; font-weight: 500;"
           >
             Fund Name
           </th>
           <th
-            style="padding: 0.75rem; text-align: left;"
+            style="padding: 0.75rem; text-align: left; font-weight: 500;"
           >
             Type
           </th>
           <th
-            style="padding: 0.75rem; text-align: center;"
+            style="padding: 0.75rem; text-align: center; font-weight: 500;"
           >
             Score
           </th>
           <th
-            style="padding: 0.75rem; text-align: right;"
+            style="padding: 0.75rem; text-align: right; font-weight: 500;"
           >
             YTD
           </th>
           <th
-            style="padding: 0.75rem; text-align: right;"
+            style="padding: 0.75rem; text-align: right; font-weight: 500;"
           >
             1Y
           </th>
           <th
-            style="padding: 0.75rem; text-align: right;"
+            style="padding: 0.75rem; text-align: right; font-weight: 500;"
           >
             3Y
           </th>
           <th
-            style="padding: 0.75rem; text-align: right;"
+            style="padding: 0.75rem; text-align: right; font-weight: 500;"
           >
             5Y
           </th>
           <th
-            style="padding: 0.75rem; text-align: right;"
+            style="padding: 0.75rem; text-align: right; font-weight: 500;"
           >
             Sharpe
           </th>
           <th
-            style="padding: 0.75rem; text-align: right;"
+            style="padding: 0.75rem; text-align: right; font-weight: 500;"
           >
             Std Dev (5Y)
           </th>
           <th
-            style="padding: 0.75rem; text-align: right;"
+            style="padding: 0.75rem; text-align: right; font-weight: 500;"
           >
             Expense
           </th>
           <th
-            style="padding: 0.75rem; text-align: left;"
+            style="padding: 0.75rem; text-align: left; font-weight: 500;"
           >
             Tags
           </th>
@@ -97,7 +97,7 @@ exports[`renders table snapshot 1`] = `
             style="padding: 0.5rem; text-align: center;"
           >
             <span
-              style="background-color: rgba(22, 163, 74, 0.125); color: rgb(22, 163, 74); border: 1px solid #16a34a50; border-radius: 9999px; font-size: 0.75rem; padding: 0.25rem 0.5rem; display: inline-block; min-width: 3rem; text-align: center;"
+              style="background-color: rgba(22, 163, 74, 0.125); color: rgb(22, 163, 74); border: 1px solid #16a34a50; border-radius: 9999px; font-size: 0.75rem; font-weight: bold; padding: 0.25rem 0.5rem; display: inline-block; min-width: 3rem; text-align: center;"
             >
               75 - Strong
             </span>


### PR DESCRIPTION
## Summary
- style tables with consistent padding and weight
- add sticky selector in ClassView
- switch dashboard cards to CSS grid
- implement `GroupedFundTable` accordion and toggle
- update tests for grouped view and new snapshot

## Testing
- `npm test -- -u --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68595699fd84832996f8b70690b5ed9b