### PR TITLE
UI polish and scoring refinement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,7 @@
 - Benchmarks preserved during scoring; debug log shows benchmark count.
 - Added benchmark audit script and flow documentation; dashboard views show benchmarks by default.
 - Grouped fund scores view with accordion sections and toggle; UI polish on tables and dashboard grid.
+- Score badges now share Tailwind styling and color mapping.
+- Dashboard tiles use shadowed cards; responsive table columns hide on mobile.
+- Scoring engine uses weighted z-scores with percentile scaling; benchmarks excluded from peer stats.
+- Added unit test ensuring VFIAX percentile between 40-60.

--- a/src/components/BenchmarkRow.jsx
+++ b/src/components/BenchmarkRow.jsx
@@ -1,63 +1,26 @@
 import React from 'react';
-import { getScoreColor, getScoreLabel } from '../services/scoring';
 import { fmtPct, fmtNumber } from '../utils/formatters';
-
-const ScoreBadge = ({ score }) => {
-  const color = getScoreColor(score);
-  const label = getScoreLabel(score);
-  return (
-    <span
-      style={{
-        backgroundColor: `${color}20`,
-        color,
-        border: `1px solid ${color}50`,
-        borderRadius: '9999px',
-        fontSize: '0.75rem',
-        fontWeight: 'bold',
-        padding: '0.25rem 0.5rem',
-        display: 'inline-block',
-        minWidth: '3rem',
-        textAlign: 'center'
-      }}
-    >
-      {score} - {label}
-    </span>
-  );
-};
+import ScoreBadge from './common/ScoreBadge.jsx';
 
 const BenchmarkRow = ({ data, fund }) => {
   const row = data || fund;
   if (!row) return null;
   return (
-    <table style={{ width: '100%', borderCollapse: 'collapse', marginBottom: '0.5rem' }}>
+    <table className="w-full border-collapse mb-2">
       <tbody>
         <tr className="benchmark-banner">
-          <td style={{ padding: '0.75rem' }}>{`Benchmark — ${row.Symbol}`}</td>
-          <td style={{ padding: '0.75rem' }}>{row['Fund Name'] || row.name}</td>
-          <td style={{ padding: '0.75rem', textAlign: 'center' }}>
+          <td className="px-3 py-1">{`Benchmark — ${row.Symbol}`}</td>
+          <td className="px-3 py-1">{row['Fund Name'] || row.name}</td>
+          <td className="px-3 py-1 text-center">
             {row.scores ? <ScoreBadge score={row.scores.final} /> : '-'}
           </td>
-          <td style={{ padding: '0.75rem', textAlign: 'right' }}>
-            {fmtPct(row.ytd ?? row.YTD)}
-          </td>
-          <td style={{ padding: '0.75rem', textAlign: 'right' }}>
-            {fmtPct(row.oneYear ?? row['1 Year'])}
-          </td>
-          <td style={{ padding: '0.75rem', textAlign: 'right' }}>
-            {fmtPct(row.threeYear ?? row['3 Year'])}
-          </td>
-          <td style={{ padding: '0.75rem', textAlign: 'right' }}>
-            {fmtPct(row.fiveYear ?? row['5 Year'])}
-          </td>
-          <td style={{ padding: '0.75rem', textAlign: 'right' }}>
-            {fmtNumber(row.sharpe ?? row['Sharpe Ratio'])}
-          </td>
-          <td style={{ padding: '0.75rem', textAlign: 'right' }}>
-            {fmtPct(row.stdDev5y ?? row['Standard Deviation'])}
-          </td>
-          <td style={{ padding: '0.75rem', textAlign: 'right' }}>
-            {fmtPct(row.expense ?? row['Net Expense Ratio'])}
-          </td>
+          <td className="px-3 py-1 text-right">{fmtPct(row.ytd ?? row.YTD)}</td>
+          <td className="px-3 py-1 text-right">{fmtPct(row.oneYear ?? row['1 Year'])}</td>
+          <td className="px-3 py-1 text-right hidden sm:table-cell">{fmtPct(row.threeYear ?? row['3 Year'])}</td>
+          <td className="px-3 py-1 text-right hidden sm:table-cell">{fmtPct(row.fiveYear ?? row['5 Year'])}</td>
+          <td className="px-3 py-1 text-right">{fmtNumber(row.sharpe ?? row['Sharpe Ratio'])}</td>
+          <td className="px-3 py-1 text-right hidden sm:table-cell">{fmtPct(row.stdDev5y ?? row['Standard Deviation'])}</td>
+          <td className="px-3 py-1 text-right hidden sm:table-cell">{fmtPct(row.expense ?? row['Net Expense Ratio'])}</td>
         </tr>
       </tbody>
     </table>

--- a/src/components/Dashboard/AssetClassOverview.jsx
+++ b/src/components/Dashboard/AssetClassOverview.jsx
@@ -102,19 +102,12 @@ const AssetClassOverview = ({ funds, config }) => {
         <Layers size={18} /> Asset Class Overview
       </h3>
 
-      <div className="dashboard-grid">
+      <div className="dashboard-grid grid grid-cols-2 md:grid-cols-4 gap-4">
         {classInfo.map(info => (
           <div
             key={info.assetClass}
-            style={{
-              border: '1px solid #e5e7eb',
-              borderRadius: '0.5rem',
-              padding: '0.75rem',
-              backgroundColor: `${info.color}10`,
-              display: 'flex',
-              flexDirection: 'column',
-              gap: '0.25rem'
-            }}
+            className="shadow-sm rounded-xl p-4 bg-white flex flex-col gap-1"
+            style={{ backgroundColor: `${info.color}10` }}
           >
             <div style={{ fontWeight: 600 }}>{info.assetClass}</div>
 

--- a/src/components/Dashboard/PerformanceHeatmap.jsx
+++ b/src/components/Dashboard/PerformanceHeatmap.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { getScoreColor } from '../../services/scoring';
 import { LayoutGrid } from 'lucide-react';
 import TagList from '../TagList.jsx';
+import ScoreBadge from '../common/ScoreBadge.jsx';
 
 /**
  * Render a heatmap of fund scores grouped by asset class.
@@ -15,26 +16,6 @@ import TagList from '../TagList.jsx';
  *   - isRecommended
  *   - isBenchmark
  */
-const ScoreBadge = ({ score }) => {
-  const color = getScoreColor(score);
-  return (
-    <span
-      style={{
-        backgroundColor: `${color}20`,
-        color,
-        border: `1px solid ${color}50`,
-        borderRadius: '9999px',
-        fontSize: '0.75rem',
-        padding: '0.125rem 0.5rem',
-        display: 'inline-block',
-        minWidth: '2.5rem',
-        textAlign: 'center'
-      }}
-    >
-      {score}
-    </span>
-  );
-};
 
 const FundTile = ({ fund }) => {
   const color = getScoreColor(fund.scores?.final || 0);
@@ -49,19 +30,12 @@ const FundTile = ({ fund }) => {
   return (
     <div
       title={tooltipParts.join(' | ')}
-      style={{
-        backgroundColor: `${color}20`,
-        border: `1px solid ${color}50`,
-        borderRadius: '0.5rem',
-        padding: '0.5rem',
-        display: 'flex',
-        flexDirection: 'column',
-        gap: '0.25rem'
-      }}
+      className="rounded-lg p-2 border"
+      style={{ backgroundColor: `${color}20`, borderColor: `${color}50` }}
     >
       <div style={{ fontWeight: 600 }}>{fund['Fund Name']}</div>
       <div style={{ fontSize: '0.875rem', color: '#374151' }}>{fund.Symbol}</div>
-      <ScoreBadge score={fund.scores?.final || 0} />
+      <ScoreBadge score={fund.scores?.final || 0} size="small" />
       {Array.isArray(fund.tags) && fund.tags.length > 0 && (
         <TagList tags={fund.tags} />
       )}
@@ -112,13 +86,7 @@ const PerformanceHeatmap = ({ funds }) => {
         return (
           <div key={assetClass} style={{ marginBottom: '1rem' }}>
             <h4 style={{ fontWeight: 'bold', marginBottom: '0.25rem' }}>{assetClass}</h4>
-            <div
-              style={{
-                display: 'grid',
-                gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))',
-                gap: '0.5rem'
-              }}
-            >
+            <div className="grid gap-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
               {benchmark && <FundTile key={benchmark.Symbol} fund={benchmark} />}
               {classFunds.map(fund => (
                 <FundTile key={fund.Symbol} fund={fund} />

--- a/src/components/Dashboard/TopBottomPerformers.jsx
+++ b/src/components/Dashboard/TopBottomPerformers.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { getScoreColor, getScoreLabel } from '../../services/scoring';
 import TagList from '../TagList.jsx';
+import ScoreBadge from '../common/ScoreBadge.jsx';
 import { BarChart2 } from 'lucide-react';
 
 /**
@@ -14,55 +14,25 @@ import { BarChart2 } from 'lucide-react';
  *   - isBenchmark
  *   - isRecommended
  */
-const ScoreBadge = ({ score }) => {
-  const color = getScoreColor(score);
-  const label = getScoreLabel(score);
-  return (
-    <span
-      style={{
-        backgroundColor: `${color}20`,
-        color,
-        border: `1px solid ${color}50`,
-        borderRadius: '9999px',
-        fontSize: '0.75rem',
-        padding: '0.25rem 0.5rem',
-        display: 'inline-block',
-        minWidth: '3rem',
-        textAlign: 'center'
-      }}
-    >
-      {score} - {label}
-    </span>
-  );
-};
 
 const FundRow = ({ fund }) => (
-  <tr style={{ borderBottom: '1px solid #f3f4f6' }}>
-    <td style={{ padding: '0.5rem' }}>{fund['Fund Name']}</td>
-    <td style={{ padding: '0.5rem' }}>{fund.Symbol}</td>
-    <td style={{ padding: '0.5rem' }}>{fund.assetClass}</td>
-    <td style={{ padding: '0.5rem', textAlign: 'center' }}>
+  <tr className="border-b">
+    <td className="px-3 py-1">{fund['Fund Name']}</td>
+    <td className="px-3 py-1">{fund.Symbol}</td>
+    <td className="px-3 py-1">{fund.assetClass}</td>
+    <td className="px-3 py-1 text-center">
       <ScoreBadge score={fund.scores?.final || 0} />
     </td>
-    <td style={{ padding: '0.5rem' }}>
+    <td className="px-3 py-1">
       {Array.isArray(fund.tags) && fund.tags.length > 0 ? (
         <TagList tags={fund.tags} />
       ) : (
-        <span style={{ color: '#9ca3af' }}>-</span>
+        <span className="text-gray-400">-</span>
       )}
     </td>
-    <td style={{ padding: '0.5rem' }}>
+    <td className="px-3 py-1">
       {fund.isBenchmark && (
-        <span
-          style={{
-            backgroundColor: '#fbbf24',
-            color: '#78350f',
-            padding: '0.125rem 0.5rem',
-            borderRadius: '0.25rem',
-            fontSize: '0.75rem',
-            fontWeight: '500'
-          }}
-        >
+        <span className="bg-yellow-200 text-yellow-800 px-2 py-0.5 rounded text-xs font-medium">
           Benchmark
         </span>
       )}
@@ -92,18 +62,18 @@ const TopBottomPerformers = ({ funds }) => {
         <BarChart2 size={18} /> Top &amp; Bottom Performers
       </h3>
 
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))', gap: '1rem' }}>
+      <div className="grid gap-4 md:grid-cols-2">
         <div>
           <h4 style={{ fontWeight: 'bold', marginBottom: '0.25rem' }}>Top 5</h4>
-          <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+          <table className="w-full border-collapse">
             <thead>
-              <tr style={{ borderBottom: '2px solid #e5e7eb' }}>
-                <th style={{ textAlign: 'left', padding: '0.5rem' }}>Fund</th>
-                <th style={{ textAlign: 'left', padding: '0.5rem' }}>Ticker</th>
-                <th style={{ textAlign: 'left', padding: '0.5rem' }}>Class</th>
-                <th style={{ textAlign: 'center', padding: '0.5rem' }}>Score</th>
-                <th style={{ textAlign: 'left', padding: '0.5rem' }}>Tags</th>
-                <th style={{ padding: '0.5rem' }}></th>
+              <tr className="border-b-2 border-gray-200">
+                <th className="px-3 py-1 text-left">Fund</th>
+                <th className="px-3 py-1 text-left">Ticker</th>
+                <th className="px-3 py-1 text-left">Class</th>
+                <th className="px-3 py-1 text-center">Score</th>
+                <th className="px-3 py-1 text-left">Tags</th>
+                <th className="px-3 py-1"></th>
               </tr>
             </thead>
             <tbody>
@@ -116,15 +86,15 @@ const TopBottomPerformers = ({ funds }) => {
 
         <div>
           <h4 style={{ fontWeight: 'bold', marginBottom: '0.25rem' }}>Bottom 5</h4>
-          <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+          <table className="w-full border-collapse">
             <thead>
-              <tr style={{ borderBottom: '2px solid #e5e7eb' }}>
-                <th style={{ textAlign: 'left', padding: '0.5rem' }}>Fund</th>
-                <th style={{ textAlign: 'left', padding: '0.5rem' }}>Ticker</th>
-                <th style={{ textAlign: 'left', padding: '0.5rem' }}>Class</th>
-                <th style={{ textAlign: 'center', padding: '0.5rem' }}>Score</th>
-                <th style={{ textAlign: 'left', padding: '0.5rem' }}>Tags</th>
-                <th style={{ padding: '0.5rem' }}></th>
+              <tr className="border-b-2 border-gray-200">
+                <th className="px-3 py-1 text-left">Fund</th>
+                <th className="px-3 py-1 text-left">Ticker</th>
+                <th className="px-3 py-1 text-left">Class</th>
+                <th className="px-3 py-1 text-center">Score</th>
+                <th className="px-3 py-1 text-left">Tags</th>
+                <th className="px-3 py-1"></th>
               </tr>
             </thead>
             <tbody>

--- a/src/components/FundTable.jsx
+++ b/src/components/FundTable.jsx
@@ -1,100 +1,59 @@
 import React from 'react';
 import TagList from './TagList.jsx';
-import { getScoreColor, getScoreLabel } from '../services/scoring';
+import ScoreBadge from './common/ScoreBadge.jsx';
 import { fmtPct, fmtNumber } from '../utils/formatters';
-
-const ScoreBadge = ({ score }) => {
-  const color = getScoreColor(score);
-  const label = getScoreLabel(score);
-  return (
-    <span
-      style={{
-        backgroundColor: `${color}20`,
-        color,
-        border: `1px solid ${color}50`,
-        borderRadius: '9999px',
-        fontSize: '0.75rem',
-        fontWeight: 'bold',
-        padding: '0.25rem 0.5rem',
-        display: 'inline-block',
-        minWidth: '3rem',
-        textAlign: 'center'
-      }}
-    >
-      {score} - {label}
-    </span>
-  );
-};
 
 const FundTable = ({ funds = [], rows, onRowClick = () => {} }) => {
   const data = rows || funds;
   return (
-    <div style={{ overflowX: 'auto' }}>
-      <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+    <div className="overflow-x-auto">
+      <table className="w-full border-collapse">
       <thead>
-        <tr style={{ borderBottom: '2px solid #e5e7eb' }}>
-          <th style={{ padding: '0.75rem', textAlign: 'left', fontWeight: 500 }}>Symbol</th>
-          <th style={{ padding: '0.75rem', textAlign: 'left', fontWeight: 500 }}>Fund Name</th>
-          <th style={{ padding: '0.75rem', textAlign: 'left', fontWeight: 500 }}>Type</th>
-          <th style={{ padding: '0.75rem', textAlign: 'center', fontWeight: 500 }}>Score</th>
-          <th style={{ padding: '0.75rem', textAlign: 'right', fontWeight: 500 }}>YTD</th>
-          <th style={{ padding: '0.75rem', textAlign: 'right', fontWeight: 500 }}>1Y</th>
-          <th style={{ padding: '0.75rem', textAlign: 'right', fontWeight: 500 }}>3Y</th>
-          <th style={{ padding: '0.75rem', textAlign: 'right', fontWeight: 500 }}>5Y</th>
-          <th style={{ padding: '0.75rem', textAlign: 'right', fontWeight: 500 }}>Sharpe</th>
-          <th style={{ padding: '0.75rem', textAlign: 'right', fontWeight: 500 }}>Std Dev (5Y)</th>
-          <th style={{ padding: '0.75rem', textAlign: 'right', fontWeight: 500 }}>Expense</th>
-          <th style={{ padding: '0.75rem', textAlign: 'left', fontWeight: 500 }}>Tags</th>
+        <tr className="border-b-2 border-gray-200">
+          <th className="px-3 py-1 text-left font-medium">Symbol</th>
+          <th className="px-3 py-1 text-left font-medium">Fund Name</th>
+          <th className="px-3 py-1 text-left font-medium">Type</th>
+          <th className="px-3 py-1 text-center font-medium">Score</th>
+          <th className="px-3 py-1 text-right font-medium">YTD</th>
+          <th className="px-3 py-1 text-right font-medium">1Y</th>
+          <th className="px-3 py-1 text-right font-medium hidden sm:table-cell">3Y</th>
+          <th className="px-3 py-1 text-right font-medium hidden sm:table-cell">5Y</th>
+          <th className="px-3 py-1 text-right font-medium">Sharpe</th>
+          <th className="px-3 py-1 text-right font-medium hidden sm:table-cell">Std Dev (5Y)</th>
+          <th className="px-3 py-1 text-right font-medium hidden sm:table-cell">Expense</th>
+          <th className="px-3 py-1 text-left font-medium">Tags</th>
         </tr>
       </thead>
       <tbody>
         {data.map(fund => (
           <tr
             key={fund.Symbol}
-            style={{
-              borderBottom: '1px solid #f3f4f6',
-              cursor: 'pointer',
-              backgroundColor: fund.isBenchmark ? '#fffbeb' : 'transparent'
-            }}
+            className={`border-b cursor-pointer ${fund.isBenchmark ? 'bg-yellow-50' : ''}`}
             role="button"
             tabIndex={0}
             onKeyDown={e => e.key === 'Enter' && onRowClick(fund)}
             onClick={() => onRowClick(fund)}
           >
-            <td style={{ padding: '0.5rem' }}>{fund.Symbol}</td>
-            <td style={{ padding: '0.5rem' }}>{fund['Fund Name']}</td>
-            <td style={{ padding: '0.5rem' }}>
+            <td className="px-3 py-1">{fund.Symbol}</td>
+            <td className="px-3 py-1">{fund['Fund Name']}</td>
+            <td className="px-3 py-1">
               {fund.isBenchmark ? 'Benchmark' : fund.isRecommended ? 'Recommended' : ''}
             </td>
-            <td style={{ padding: '0.5rem', textAlign: 'center' }}>
+            <td className="px-3 py-1 text-center">
               {fund.scores ? <ScoreBadge score={fund.scores.final} /> : '-'}
             </td>
-            <td style={{ padding: '0.5rem', textAlign: 'right' }}>
-              {fmtPct(fund.ytd ?? fund.YTD)}
-            </td>
-            <td style={{ padding: '0.5rem', textAlign: 'right' }}>
-              {fmtPct(fund.oneYear ?? fund['1 Year'])}
-            </td>
-            <td style={{ padding: '0.5rem', textAlign: 'right' }}>
-              {fmtPct(fund.threeYear ?? fund['3 Year'])}
-            </td>
-            <td style={{ padding: '0.5rem', textAlign: 'right' }}>
-              {fmtPct(fund.fiveYear ?? fund['5 Year'])}
-            </td>
-            <td style={{ padding: '0.5rem', textAlign: 'right' }}>
-              {fmtNumber(fund.sharpe ?? fund['Sharpe Ratio'])}
-            </td>
-            <td style={{ padding: '0.5rem', textAlign: 'right' }}>
-              {fmtPct(fund.stdDev5y ?? fund['Standard Deviation'])}
-            </td>
-            <td style={{ padding: '0.5rem', textAlign: 'right' }}>
-              {fmtPct(fund.expense ?? fund['Net Expense Ratio'])}
-            </td>
-            <td style={{ padding: '0.5rem' }}>
+            <td className="px-3 py-1 text-right">{fmtPct(fund.ytd ?? fund.YTD)}</td>
+            <td className="px-3 py-1 text-right">{fmtPct(fund.oneYear ?? fund['1 Year'])}</td>
+            <td className="px-3 py-1 text-right hidden sm:table-cell">{fmtPct(fund.threeYear ?? fund['3 Year'])}</td>
+            <td className="px-3 py-1 text-right hidden sm:table-cell">{fmtPct(fund.fiveYear ?? fund['5 Year'])}</td>
+            <td className="px-3 py-1 text-right">{fmtNumber(fund.sharpe ?? fund['Sharpe Ratio'])}</td>
+            <td className="px-3 py-1 text-right hidden sm:table-cell">{fmtPct(fund.stdDev5y ?? fund['Standard Deviation'])}</td>
+            <td className="px-3 py-1 text-right hidden sm:table-cell">{fmtPct(fund.expense ?? fund['Net Expense Ratio'])}</td>
+            <td className="px-3 py-1">
               {Array.isArray(fund.tags) && fund.tags.length > 0 ? (
                 <TagList tags={fund.tags} />
               ) : (
-                <span style={{ color: '#9ca3af' }}>-</span>
+                <span className="text-gray-400">-</span>
               )}
             </td>
           </tr>

--- a/src/components/GroupedFundTable.jsx
+++ b/src/components/GroupedFundTable.jsx
@@ -31,17 +31,12 @@ const GroupedFundTable = ({ funds = [], onRowClick = () => {} }) => {
           : 0;
         const benchScore = benchmark?.scores?.final;
         return (
-          <div key={cls} style={{ marginBottom: '1rem' }}>
+          <div key={cls} className="mb-4">
             <div
               onClick={() => toggle(cls)}
-              style={{
-                cursor: 'pointer',
-                fontWeight: '500',
-                display: 'flex',
-                justifyContent: 'space-between',
-                padding: '0.5rem 0',
-                borderBottom: '1px solid #e5e7eb'
-              }}
+              className={`cursor-pointer font-medium flex justify-between py-2 border-b ${
+                open[cls] ? 'sticky top-0 z-10 bg-white' : ''
+              }`}
             >
               <span>{cls}</span>
               <span>

--- a/src/components/__tests__/__snapshots__/FundTable.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/FundTable.test.jsx.snap
@@ -3,72 +3,72 @@
 exports[`renders table snapshot 1`] = `
 <DocumentFragment>
   <div
-    style="overflow-x: auto;"
+    class="overflow-x-auto"
   >
     <table
-      style="width: 100%; border-collapse: collapse;"
+      class="w-full border-collapse"
     >
       <thead>
         <tr
-          style="border-bottom: 2px solid #e5e7eb;"
+          class="border-b-2 border-gray-200"
         >
           <th
-            style="padding: 0.75rem; text-align: left; font-weight: 500;"
+            class="px-3 py-1 text-left font-medium"
           >
             Symbol
           </th>
           <th
-            style="padding: 0.75rem; text-align: left; font-weight: 500;"
+            class="px-3 py-1 text-left font-medium"
           >
             Fund Name
           </th>
           <th
-            style="padding: 0.75rem; text-align: left; font-weight: 500;"
+            class="px-3 py-1 text-left font-medium"
           >
             Type
           </th>
           <th
-            style="padding: 0.75rem; text-align: center; font-weight: 500;"
+            class="px-3 py-1 text-center font-medium"
           >
             Score
           </th>
           <th
-            style="padding: 0.75rem; text-align: right; font-weight: 500;"
+            class="px-3 py-1 text-right font-medium"
           >
             YTD
           </th>
           <th
-            style="padding: 0.75rem; text-align: right; font-weight: 500;"
+            class="px-3 py-1 text-right font-medium"
           >
             1Y
           </th>
           <th
-            style="padding: 0.75rem; text-align: right; font-weight: 500;"
+            class="px-3 py-1 text-right font-medium hidden sm:table-cell"
           >
             3Y
           </th>
           <th
-            style="padding: 0.75rem; text-align: right; font-weight: 500;"
+            class="px-3 py-1 text-right font-medium hidden sm:table-cell"
           >
             5Y
           </th>
           <th
-            style="padding: 0.75rem; text-align: right; font-weight: 500;"
+            class="px-3 py-1 text-right font-medium"
           >
             Sharpe
           </th>
           <th
-            style="padding: 0.75rem; text-align: right; font-weight: 500;"
+            class="px-3 py-1 text-right font-medium hidden sm:table-cell"
           >
             Std Dev (5Y)
           </th>
           <th
-            style="padding: 0.75rem; text-align: right; font-weight: 500;"
+            class="px-3 py-1 text-right font-medium hidden sm:table-cell"
           >
             Expense
           </th>
           <th
-            style="padding: 0.75rem; text-align: left; font-weight: 500;"
+            class="px-3 py-1 text-left font-medium"
           >
             Tags
           </th>
@@ -76,69 +76,70 @@ exports[`renders table snapshot 1`] = `
       </thead>
       <tbody>
         <tr
+          class="border-b cursor-pointer "
           role="button"
-          style="border-bottom: 1px solid #f3f4f6; cursor: pointer; background-color: transparent;"
           tabindex="0"
         >
           <td
-            style="padding: 0.5rem;"
+            class="px-3 py-1"
           >
             ABC
           </td>
           <td
-            style="padding: 0.5rem;"
+            class="px-3 py-1"
           >
             Alpha Fund
           </td>
           <td
-            style="padding: 0.5rem;"
+            class="px-3 py-1"
           />
           <td
-            style="padding: 0.5rem; text-align: center;"
+            class="px-3 py-1 text-center"
           >
             <span
-              style="background-color: rgba(22, 163, 74, 0.125); color: rgb(22, 163, 74); border: 1px solid #16a34a50; border-radius: 9999px; font-size: 0.75rem; font-weight: bold; padding: 0.25rem 0.5rem; display: inline-block; min-width: 3rem; text-align: center;"
+              class="inline-flex items-center font-medium rounded-full border text-sm px-3 py-1 bg-green-100 text-green-700"
+              style="border-color: #16a34a50;"
             >
               75 - Strong
             </span>
           </td>
           <td
-            style="padding: 0.5rem; text-align: right;"
+            class="px-3 py-1 text-right"
           >
             2.00 %
           </td>
           <td
-            style="padding: 0.5rem; text-align: right;"
+            class="px-3 py-1 text-right"
           >
             10.00 %
           </td>
           <td
-            style="padding: 0.5rem; text-align: right;"
+            class="px-3 py-1 text-right hidden sm:table-cell"
           >
             12.00 %
           </td>
           <td
-            style="padding: 0.5rem; text-align: right;"
+            class="px-3 py-1 text-right hidden sm:table-cell"
           >
             15.00 %
           </td>
           <td
-            style="padding: 0.5rem; text-align: right;"
+            class="px-3 py-1 text-right"
           >
             0.80
           </td>
           <td
-            style="padding: 0.5rem; text-align: right;"
+            class="px-3 py-1 text-right hidden sm:table-cell"
           >
             18.00 %
           </td>
           <td
-            style="padding: 0.5rem; text-align: right;"
+            class="px-3 py-1 text-right hidden sm:table-cell"
           >
             0.50 %
           </td>
           <td
-            style="padding: 0.5rem;"
+            class="px-3 py-1"
           >
             <div
               style="display: flex; flex-wrap: wrap; gap: 0.25rem;"

--- a/src/components/common/ScoreBadge.jsx
+++ b/src/components/common/ScoreBadge.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { getScoreColor, getScoreLabel } from '../../services/scoring';
+
+const levelClasses = {
+  Strong: 'bg-green-100 text-green-700',
+  Average: 'bg-yellow-100 text-yellow-700',
+  Weak: 'bg-red-100 text-red-700'
+};
+
+/**
+ * Display a score with colored pill styling.
+ * @param {number} score
+ * @param {string} size - small|normal|large
+ */
+const ScoreBadge = ({ score = 0, size = 'normal' }) => {
+  const color = getScoreColor(score);
+  const label = getScoreLabel(score);
+  const base = 'inline-flex items-center font-medium rounded-full border';
+  const sizeMap = {
+    small: 'text-xs px-2 py-0.5',
+    normal: 'text-sm px-3 py-1',
+    large: 'text-base px-4 py-1.5'
+  };
+  const levelClass = levelClasses[label] || 'bg-gray-100 text-gray-700';
+
+  return (
+    <span
+      className={`${base} ${sizeMap[size]} ${levelClass}`}
+      style={{ borderColor: `${color}50` }}
+    >
+      {score} - {label}
+    </span>
+  );
+};
+
+export default ScoreBadge;

--- a/src/services/__tests__/vfiaxScore.test.js
+++ b/src/services/__tests__/vfiaxScore.test.js
@@ -1,0 +1,69 @@
+import { calculateScores } from '../scoring';
+
+describe('VFIAX scoring', () => {
+  test('VFIAX percentile between 40 and 60 in Large Cap Blend', () => {
+    const sample = [
+      {
+        Symbol: 'AAA',
+        'Fund Name': 'Fund A',
+        assetClass: 'Large Cap Blend',
+        '1 Year': 12,
+        '3 Year': 14,
+        '5 Year': 16,
+        'Sharpe Ratio': 1.2,
+        'Standard Deviation': 15,
+        'Net Expense Ratio': 0.5
+      },
+      {
+        Symbol: 'BBB',
+        'Fund Name': 'Fund B',
+        assetClass: 'Large Cap Blend',
+        '1 Year': 8,
+        '3 Year': 9,
+        '5 Year': 10,
+        'Sharpe Ratio': 0.8,
+        'Standard Deviation': 18,
+        'Net Expense Ratio': 0.6
+      },
+      {
+        Symbol: 'CCC',
+        'Fund Name': 'Fund C',
+        assetClass: 'Large Cap Blend',
+        '1 Year': 9,
+        '3 Year': 11,
+        '5 Year': 12,
+        'Sharpe Ratio': 0.9,
+        'Standard Deviation': 16,
+        'Net Expense Ratio': 0.4
+      },
+      {
+        Symbol: 'VFIAX',
+        'Fund Name': 'Vanguard 500 Index Admiral',
+        assetClass: 'Large Cap Blend',
+        '1 Year': 10,
+        '3 Year': 12,
+        '5 Year': 14,
+        'Sharpe Ratio': 1.0,
+        'Standard Deviation': 15.5,
+        'Net Expense Ratio': 0.05
+      },
+      {
+        Symbol: 'IWB',
+        'Fund Name': 'Russell 1000',
+        assetClass: 'Large Cap Blend',
+        '1 Year': 11,
+        '3 Year': 13,
+        '5 Year': 15,
+        'Sharpe Ratio': 1.1,
+        'Standard Deviation': 16,
+        'Net Expense Ratio': 0.2,
+        isBenchmark: true
+      }
+    ];
+
+    const scored = calculateScores(sample);
+    const vfiax = scored.find(f => f.Symbol === 'VFIAX');
+    expect(vfiax.scores.percentile).toBeGreaterThanOrEqual(40);
+    expect(vfiax.scores.percentile).toBeLessThanOrEqual(60);
+  });
+});

--- a/src/services/scoring.js
+++ b/src/services/scoring.js
@@ -84,14 +84,9 @@ const METRIC_WEIGHTS = {
    * @returns {number} Score scaled to 0-100
    */
   function scaleScore(rawScore, allRawScores) {
-    // Calculate percentile-based scaling
-    // This ensures 50 represents the median of the peer group
-    const sortedScores = [...allRawScores].sort((a, b) => a - b);
-    const position = sortedScores.findIndex(s => s >= rawScore);
-    const percentile = position === -1 ? 100 : (position / sortedScores.length) * 100;
-    
-    // Map percentile to 0-100 scale with some smoothing
-    // This gives us better distribution than linear scaling
+    const sorted = [...allRawScores].sort((a, b) => a - b);
+    const better = sorted.filter(s => s < rawScore).length;
+    const percentile = (better / sorted.length) * 100;
     return Math.round(percentile);
   }
   


### PR DESCRIPTION
## Summary
- unify score badge styles and colors
- apply card styling and responsive grids on the dashboard
- update fund tables and accordion headers with Tailwind classes
- refine percentile scaling in scoring engine
- add regression test for VFIAX percentile

## Testing
- `CI=true npm test -- -u --runInBand`
- `CI=true npm start`

------
https://chatgpt.com/codex/tasks/task_e_685959a3e32083299ddc5a4aa0b297db