### PR TITLE
Add web worker for heavy fund processing

### DIFF
--- a/src/services/__tests__/fundProcessingService.test.js
+++ b/src/services/__tests__/fundProcessingService.test.js
@@ -1,0 +1,43 @@
+import { process } from '../fundProcessingService';
+import parseFundFile from '../parseFundFile';
+import { ensureBenchmarkRows } from '../dataLoader';
+import { calculateScores } from '../scoring';
+import { applyTagRules } from '../tagEngine';
+import dataStore from '../dataStore';
+import * as XLSX from 'xlsx';
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+jest.mock('../parseFundFile');
+jest.mock('../dataLoader', () => ({ ensureBenchmarkRows: jest.fn() }));
+jest.mock('../scoring', () => ({ calculateScores: jest.fn() }));
+jest.mock('../tagEngine', () => ({ applyTagRules: jest.fn() }));
+jest.mock('../dataStore', () => ({ saveSnapshot: jest.fn(), getSnapshot: jest.fn() }));
+jest.mock('xlsx');
+
+test('process executes helpers in order', async () => {
+  const rows = [['a']];
+  XLSX.read.mockReturnValue({ SheetNames: ['s'], Sheets: { s: {} } });
+  XLSX.utils.sheet_to_json.mockReturnValue(rows);
+  parseFundFile.mockResolvedValue('parsed');
+  ensureBenchmarkRows.mockReturnValue('bench');
+  calculateScores.mockReturnValue('scored');
+  applyTagRules.mockReturnValue('tagged');
+  dataStore.saveSnapshot.mockResolvedValue('id1');
+
+  const file = {
+    name: 'test.xlsx',
+    arrayBuffer: async () => new ArrayBuffer(8)
+  };
+  const id = await process(file, { foo: 'bar' });
+
+  expect(XLSX.read).toHaveBeenCalled();
+  expect(parseFundFile).toHaveBeenCalledWith(rows, { foo: 'bar' });
+  expect(ensureBenchmarkRows).toHaveBeenCalledWith('parsed', { foo: 'bar' });
+  expect(calculateScores).toHaveBeenCalledWith('bench', { foo: 'bar' });
+  expect(applyTagRules).toHaveBeenCalledWith('scored', { foo: 'bar' });
+  expect(dataStore.saveSnapshot).toHaveBeenCalled();
+  expect(id).toBe('id1');
+});

--- a/src/services/fundProcessingService.js
+++ b/src/services/fundProcessingService.js
@@ -1,0 +1,35 @@
+import * as XLSX from 'xlsx';
+import parseFundFile from './parseFundFile';
+import { ensureBenchmarkRows } from './dataLoader';
+import { calculateScores } from './scoring';
+import { applyTagRules } from './tagEngine';
+import dataStore from './dataStore';
+
+/**
+ * Process an uploaded fund file through parsing, scoring and tagging.
+ * Heavy computations are isolated here for use inside a Web Worker.
+ * @param {File} file - Uploaded spreadsheet file
+ * @param {Object} config - Recommended funds and benchmarks
+ * @returns {Promise<string>} ID of the saved snapshot
+ */
+export async function process(file, config = {}) {
+  // Read file into rows using XLSX
+  const buffer = await file.arrayBuffer();
+  const workbook = XLSX.read(new Uint8Array(buffer), { type: 'array' });
+  const sheetName = workbook.SheetNames[0];
+  const worksheet = workbook.Sheets[sheetName];
+  const rows = XLSX.utils.sheet_to_json(worksheet, { header: 1 });
+
+  const raw = await parseFundFile(rows, config);
+  const withBench = ensureBenchmarkRows(raw, config);
+  const scored = calculateScores(withBench, config);
+  const tagged = applyTagRules(scored, config);
+
+  const snapshotId = await dataStore.saveSnapshot({
+    date: new Date().toISOString().slice(0, 10),
+    funds: tagged,
+    fileName: file.name
+  });
+
+  return snapshotId;
+}

--- a/src/workers/fundProcessor.worker.js
+++ b/src/workers/fundProcessor.worker.js
@@ -1,0 +1,10 @@
+self.onmessage = async ({ data }) => {
+  const { file, config } = data;
+  try {
+    const module = await import('../services/fundProcessingService.js');
+    const id = await module.process(file, config);
+    self.postMessage({ status: 'done', snapshotId: id });
+  } catch (e) {
+    self.postMessage({ status: 'error', message: e.message });
+  }
+};


### PR DESCRIPTION
## Summary
- add `fundProcessingService` to parse/score/tag funds and save snapshot
- add `fundProcessor.worker` to offload processing
- update `App.jsx` to use the worker for file uploads
- add tests for `fundProcessingService`

## Testing
- `npm test --silent -- -w=1`
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685ab6340ac48329a8acee7e14373173