### PR TITLE
Add AdminPanel validations with toast and persistence

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "papaparse": "^5.5.3",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-hook-form": "^7.49.2",
         "react-scripts": "5.0.1",
         "recharts": "^2.15.3",
         "tsx": "^4.20.3",
@@ -14853,6 +14854,22 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.1.0.tgz",
       "integrity": "sha512-SN/U6Ytxf1QGkw/9ve5Y+NxBbZM6Ht95tuXNMKs8EJyFa/Vy/+Co3stop3KBHARfn/giv+Lj1uUnTfOJ3moFEQ==",
       "license": "MIT"
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.58.1",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.58.1.tgz",
+      "integrity": "sha512-Lml/KZYEEFfPhUVgE0RdCVpnC4yhW+PndRhbiTtdvSlQTL8IfVR+iQkBjLIvmmc6+GGoVeM11z37ktKFPAb0FA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
     },
     "node_modules/react-is": {
       "version": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-scripts": "5.0.1",
+    "react-hook-form": "^7.49.2",
     "recharts": "^2.15.3",
     "tsx": "^4.20.3",
     "web-vitals": "^2.1.4",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -22,6 +22,7 @@ import { fmtPct, fmtNumber } from './utils/formatters';
 import FundScores from './components/Views/FundScores.jsx';
 import DashboardView from './components/Views/DashboardView.jsx';
 import ClassView from './components/ClassView.jsx';
+import AdminPanel from './components/AdminPanel.jsx';
 import AppContext from './context/AppContext.jsx';
 
 // Score badge component for visual display
@@ -337,28 +338,7 @@ const App = () => {
     }
   };
 
-  const updateFund = (i, field, value) => {
-    const updated = [...recommendedFunds];
-    updated[i][field] = value;
-    setRecommendedFunds(updated);
-  };
-
-  const addFund = () => {
-    setRecommendedFunds([...recommendedFunds, { symbol: '', name: '', assetClass: '' }]);
-  };
-
-  const removeFund = (i) => {
-    const updated = [...recommendedFunds];
-    updated.splice(i, 1);
-    setRecommendedFunds(updated);
-  };
-
-  const updateBenchmark = (className, field, value) => {
-    const updated = { ...assetClassBenchmarks };
-    updated[className] = { ...updated[className], [field]: value };
-    setAssetClassBenchmarks(updated);
-    setConfig(updated);
-  };
+  // CRUD helpers moved to AdminPanel component
 
 
   // Get review candidates
@@ -1038,196 +1018,14 @@ const App = () => {
         </div>
       )}
 
-      {/* Admin Tab - unchanged from original */}
       {activeTab === 'admin' && (
-        <div>
-          <h2 style={{ fontSize: '1.5rem', fontWeight: 'bold', marginBottom: '1rem' }}>Admin Panel</h2>
-          
-          <div style={{ marginBottom: '2rem' }}>
-            <h3 style={{ fontSize: '1.125rem', fontWeight: 'bold', marginBottom: '0.5rem' }}>
-              Recommended Fund List
-            </h3>
-            <button 
-              onClick={addFund} 
-              style={{ 
-                marginBottom: '0.5rem',
-                padding: '0.5rem 1rem',
-                backgroundColor: '#3b82f6',
-                color: 'white',
-                border: 'none',
-                borderRadius: '0.375rem',
-                cursor: 'pointer',
-                display: 'flex',
-                alignItems: 'center',
-                gap: '0.5rem'
-              }}
-            >
-              <Plus size={14} /> Add Fund
-            </button>
-            <table style={{ width: '100%', borderCollapse: 'collapse' }}>
-              <thead>
-                <tr style={{ borderBottom: '2px solid #e5e7eb' }}>
-                  <th style={{ padding: '0.5rem', textAlign: 'left' }}>Symbol</th>
-                  <th style={{ padding: '0.5rem', textAlign: 'left' }}>Name</th>
-                  <th style={{ padding: '0.5rem', textAlign: 'left' }}>Asset Class</th>
-                  <th style={{ padding: '0.5rem', width: '50px' }}></th>
-                </tr>
-              </thead>
-              <tbody>
-                {recommendedFunds.map((f, i) => (
-                  <tr key={i} style={{ borderBottom: '1px solid #f3f4f6' }}>
-                    <td style={{ padding: '0.5rem' }}>
-                      <input 
-                        value={f.symbol} 
-                        onChange={e => updateFund(i, 'symbol', e.target.value)}
-                        style={{ 
-                          width: '100%', 
-                          padding: '0.25rem',
-                          border: '1px solid #d1d5db',
-                          borderRadius: '0.25rem'
-                        }}
-                      />
-                    </td>
-                    <td style={{ padding: '0.5rem' }}>
-                      <input 
-                        value={f.name} 
-                        onChange={e => updateFund(i, 'name', e.target.value)}
-                        style={{ 
-                          width: '100%', 
-                          padding: '0.25rem',
-                          border: '1px solid #d1d5db',
-                          borderRadius: '0.25rem'
-                        }}
-                      />
-                    </td>
-                    <td style={{ padding: '0.5rem' }}>
-                      <input 
-                        value={f.assetClass} 
-                        onChange={e => updateFund(i, 'assetClass', e.target.value)}
-                        style={{ 
-                          width: '100%', 
-                          padding: '0.25rem',
-                          border: '1px solid #d1d5db',
-                          borderRadius: '0.25rem'
-                        }}
-                      />
-                    </td>
-                    <td style={{ padding: '0.5rem' }}>
-                      <button 
-                        onClick={() => removeFund(i)}
-                        style={{
-                          padding: '0.25rem',
-                          backgroundColor: '#ef4444',
-                          color: 'white',
-                          border: 'none',
-                          borderRadius: '0.25rem',
-                          cursor: 'pointer'
-                        }}
-                      >
-                        <Trash2 size={14} />
-                      </button>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-
-          <div>
-            <h3 style={{ fontSize: '1.125rem', fontWeight: 'bold', marginBottom: '0.5rem' }}>
-              Asset Class Benchmarks
-            </h3>
-            <button 
-              onClick={() => {
-                const newClass = prompt('Enter new Asset Class name');
-                if (!newClass || assetClassBenchmarks[newClass]) return;
-                setAssetClassBenchmarks({
-                  ...assetClassBenchmarks,
-                  [newClass]: { ticker: '', name: '' }
-                });
-                setConfig({
-                  ...assetClassBenchmarks,
-                  [newClass]: { ticker: '', name: '' }
-                });
-              }}
-              style={{ 
-                marginBottom: '0.5rem',
-                padding: '0.5rem 1rem',
-                backgroundColor: '#3b82f6',
-                color: 'white',
-                border: 'none',
-                borderRadius: '0.375rem',
-                cursor: 'pointer',
-                display: 'flex',
-                alignItems: 'center',
-                gap: '0.5rem'
-              }}
-            >
-              <Plus size={14} /> Add Asset Class
-            </button>
-            <table style={{ width: '100%', borderCollapse: 'collapse' }}>
-              <thead>
-                <tr style={{ borderBottom: '2px solid #e5e7eb' }}>
-                  <th style={{ padding: '0.5rem', textAlign: 'left' }}>Asset Class</th>
-                  <th style={{ padding: '0.5rem', textAlign: 'left' }}>ETF Ticker</th>
-                  <th style={{ padding: '0.5rem', textAlign: 'left' }}>Benchmark Name</th>
-                  <th style={{ padding: '0.5rem', width: '50px' }}></th>
-                </tr>
-              </thead>
-              <tbody>
-                {Object.entries(assetClassBenchmarks).map(([className, info], i) => (
-                  <tr key={i} style={{ borderBottom: '1px solid #f3f4f6' }}>
-                    <td style={{ padding: '0.5rem', fontWeight: '500' }}>{className}</td>
-                    <td style={{ padding: '0.5rem' }}>
-                      <input 
-                        value={info.ticker} 
-                        onChange={e => updateBenchmark(className, 'ticker', e.target.value)}
-                        style={{ 
-                          width: '100%', 
-                          padding: '0.25rem',
-                          border: '1px solid #d1d5db',
-                          borderRadius: '0.25rem'
-                        }}
-                      />
-                    </td>
-                    <td style={{ padding: '0.5rem' }}>
-                      <input 
-                        value={info.name} 
-                        onChange={e => updateBenchmark(className, 'name', e.target.value)}
-                        style={{ 
-                          width: '100%', 
-                          padding: '0.25rem',
-                          border: '1px solid #d1d5db',
-                          borderRadius: '0.25rem'
-                        }}
-                      />
-                    </td>
-                    <td style={{ padding: '0.5rem' }}>
-                      <button 
-                        onClick={() => {
-                          const copy = { ...assetClassBenchmarks };
-                          delete copy[className];
-                          setAssetClassBenchmarks(copy);
-                          setConfig(copy);
-                        }}
-                        style={{
-                          padding: '0.25rem',
-                          backgroundColor: '#ef4444',
-                          color: 'white',
-                          border: 'none',
-                          borderRadius: '0.25rem',
-                          cursor: 'pointer'
-                        }}
-                      >
-                        <Trash2 size={14} />
-                      </button>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </div>
+        <AdminPanel
+          recommendedFunds={recommendedFunds}
+          setRecommendedFunds={setRecommendedFunds}
+          assetClassBenchmarks={assetClassBenchmarks}
+          setAssetClassBenchmarks={setAssetClassBenchmarks}
+          setConfig={setConfig}
+        />
       )}
     </div>
   );

--- a/src/components/AdminPanel.jsx
+++ b/src/components/AdminPanel.jsx
@@ -1,0 +1,200 @@
+import React, { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { Plus, Trash2 } from 'lucide-react';
+import { saveStoredConfig } from '../data/storage';
+import { isValidTicker } from '../data/validators';
+
+const FormErrorMessage = ({ children }) => (
+  <p style={{ color: '#dc2626', fontSize: '0.875rem', marginTop: '0.25rem' }} role="alert">
+    {children}
+  </p>
+);
+
+const Toast = ({ type = 'info', children }) => {
+  const bg = type === 'success' ? '#d1fae5' : '#fee2e2';
+  const color = type === 'success' ? '#065f46' : '#7f1d1d';
+  return (
+    <div
+      data-testid="toast"
+      style={{
+        position: 'fixed',
+        top: '1rem',
+        right: '1rem',
+        background: bg,
+        color,
+        padding: '0.5rem 1rem',
+        borderRadius: '0.375rem',
+        boxShadow: '0 2px 4px rgba(0,0,0,0.1)'
+      }}
+    >
+      {children}
+    </div>
+  );
+};
+
+const ErrorModal = ({ message, onClose }) => (
+  <div style={{ position:'fixed', inset:0, background:'rgba(0,0,0,0.5)', display:'flex', justifyContent:'center', alignItems:'center', zIndex:1000 }}>
+    <div style={{ background:'#fff', borderRadius:'0.5rem', padding:'1.5rem', width:'300px', textAlign:'center' }}>
+      <p style={{ marginBottom:'1rem' }}>{message}</p>
+      <button onClick={onClose} style={{ padding:'0.5rem 1rem', background:'#dc2626', color:'#fff', border:'none', borderRadius:'0.375rem', cursor:'pointer' }}>Close</button>
+    </div>
+  </div>
+);
+
+const AdminPanel = ({ recommendedFunds, setRecommendedFunds, assetClassBenchmarks, setAssetClassBenchmarks, setConfig }) => {
+  const { register, handleSubmit, reset, formState:{ errors } } = useForm();
+  const [toast, setToast] = useState('');
+  const [error, setError] = useState('');
+
+  const commitConfig = async (funds, benchmarks) => {
+    try {
+      await saveStoredConfig(funds, benchmarks);
+    } catch (err) {
+      setError('Failed to save configuration');
+    }
+  };
+
+  const onAddFund = async data => {
+    const fund = {
+      symbol: data.ticker.trim().toUpperCase(),
+      name: data.name.trim(),
+      assetClass: data.assetClass.trim()
+    };
+    const updated = [...recommendedFunds, fund];
+    setRecommendedFunds(updated);
+    await commitConfig(updated, assetClassBenchmarks);
+    setToast('Fund added.');
+    setTimeout(() => setToast(''), 3000);
+    reset();
+  };
+
+  const updateFund = (i, field, value) => {
+    const updated = [...recommendedFunds];
+    updated[i][field] = value;
+    setRecommendedFunds(updated);
+    commitConfig(updated, assetClassBenchmarks);
+  };
+
+  const removeFund = i => {
+    const updated = [...recommendedFunds];
+    updated.splice(i, 1);
+    setRecommendedFunds(updated);
+    commitConfig(updated, assetClassBenchmarks);
+  };
+
+  const updateBenchmark = (className, field, value) => {
+    const updated = { ...assetClassBenchmarks };
+    updated[className] = { ...updated[className], [field]: value };
+    setAssetClassBenchmarks(updated);
+    setConfig(updated);
+    commitConfig(recommendedFunds, updated);
+  };
+
+  const addAssetClass = () => {
+    const newClass = prompt('Enter new Asset Class name');
+    if (!newClass || assetClassBenchmarks[newClass]) return;
+    const updated = { ...assetClassBenchmarks, [newClass]: { ticker: '', name: '' } };
+    setAssetClassBenchmarks(updated);
+    setConfig(updated);
+    commitConfig(recommendedFunds, updated);
+  };
+
+  return (
+    <div>
+      <h2 style={{ fontSize: '1.5rem', fontWeight: 'bold', marginBottom: '1rem' }}>Admin Panel</h2>
+      {toast && <Toast type="success">{toast}</Toast>}
+      {error && <ErrorModal message={error} onClose={() => setError('')} />}
+
+      <form onSubmit={handleSubmit(onAddFund)} style={{ marginBottom: '1.5rem', display:'flex', gap:'0.5rem', flexWrap:'wrap' }}>
+        <div style={{ display:'flex', flexDirection:'column' }}>
+          <label htmlFor="ticker">Ticker</label>
+          <input id="ticker" aria-label="Ticker" {...register('ticker', { required: 'Ticker required', validate: v => isValidTicker(v) || 'Invalid ticker' })} style={{ padding:'0.25rem', border:'1px solid #d1d5db', borderRadius:'0.25rem' }} />
+          {errors.ticker && <FormErrorMessage>{errors.ticker.message}</FormErrorMessage>}
+        </div>
+        <div style={{ display:'flex', flexDirection:'column' }}>
+          <label htmlFor="name">Name</label>
+          <input id="name" aria-label="Name" {...register('name')} style={{ padding:'0.25rem', border:'1px solid #d1d5db', borderRadius:'0.25rem' }} />
+        </div>
+        <div style={{ display:'flex', flexDirection:'column' }}>
+          <label htmlFor="assetClass">Asset Class</label>
+          <input id="assetClass" aria-label="Asset Class" {...register('assetClass', { required: 'Asset Class required' })} style={{ padding:'0.25rem', border:'1px solid #d1d5db', borderRadius:'0.25rem' }} />
+          {errors.assetClass && <FormErrorMessage>{errors.assetClass.message}</FormErrorMessage>}
+        </div>
+        <button type="submit" style={{ alignSelf:'flex-end', padding:'0.5rem 1rem', background:'#3b82f6', color:'#fff', border:'none', borderRadius:'0.375rem', cursor:'pointer', display:'flex', alignItems:'center', gap:'0.25rem' }}>
+          <Plus size={14} /> Add Fund
+        </button>
+      </form>
+
+      <div style={{ marginBottom: '2rem' }}>
+        <h3 style={{ fontSize: '1.125rem', fontWeight: 'bold', marginBottom:'0.5rem' }}>Recommended Fund List</h3>
+        <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+          <thead>
+            <tr style={{ borderBottom:'2px solid #e5e7eb' }}>
+              <th style={{ padding:'0.5rem', textAlign:'left' }}>Symbol</th>
+              <th style={{ padding:'0.5rem', textAlign:'left' }}>Name</th>
+              <th style={{ padding:'0.5rem', textAlign:'left' }}>Asset Class</th>
+              <th style={{ padding:'0.5rem', width:'50px' }}></th>
+            </tr>
+          </thead>
+          <tbody>
+            {recommendedFunds.map((f,i) => (
+              <tr key={i} style={{ borderBottom:'1px solid #f3f4f6' }}>
+                <td style={{ padding:'0.5rem' }}>
+                  <input value={f.symbol} onChange={e => updateFund(i,'symbol', e.target.value)} style={{ width:'100%', padding:'0.25rem', border:'1px solid #d1d5db', borderRadius:'0.25rem' }} />
+                </td>
+                <td style={{ padding:'0.5rem' }}>
+                  <input value={f.name} onChange={e => updateFund(i,'name', e.target.value)} style={{ width:'100%', padding:'0.25rem', border:'1px solid #d1d5db', borderRadius:'0.25rem' }} />
+                </td>
+                <td style={{ padding:'0.5rem' }}>
+                  <input value={f.assetClass} onChange={e => updateFund(i,'assetClass', e.target.value)} style={{ width:'100%', padding:'0.25rem', border:'1px solid #d1d5db', borderRadius:'0.25rem' }} />
+                </td>
+                <td style={{ padding:'0.5rem' }}>
+                  <button onClick={() => removeFund(i)} style={{ padding:'0.25rem', background:'#ef4444', color:'white', border:'none', borderRadius:'0.25rem', cursor:'pointer' }}>
+                    <Trash2 size={14} />
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <div>
+        <h3 style={{ fontSize: '1.125rem', fontWeight: 'bold', marginBottom:'0.5rem' }}>Asset Class Benchmarks</h3>
+        <button onClick={addAssetClass} style={{ marginBottom:'0.5rem', padding:'0.5rem 1rem', background:'#3b82f6', color:'white', border:'none', borderRadius:'0.375rem', cursor:'pointer', display:'flex', alignItems:'center', gap:'0.5rem' }}>
+          <Plus size={14} /> Add Asset Class
+        </button>
+        <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+          <thead>
+            <tr style={{ borderBottom:'2px solid #e5e7eb' }}>
+              <th style={{ padding:'0.5rem', textAlign:'left' }}>Asset Class</th>
+              <th style={{ padding:'0.5rem', textAlign:'left' }}>ETF Ticker</th>
+              <th style={{ padding:'0.5rem', textAlign:'left' }}>Benchmark Name</th>
+              <th style={{ padding:'0.5rem', width:'50px' }}></th>
+            </tr>
+          </thead>
+          <tbody>
+            {Object.entries(assetClassBenchmarks).map(([cls, info],i) => (
+              <tr key={i} style={{ borderBottom:'1px solid #f3f4f6' }}>
+                <td style={{ padding:'0.5rem', fontWeight:'500' }}>{cls}</td>
+                <td style={{ padding:'0.5rem' }}>
+                  <input value={info.ticker} onChange={e => updateBenchmark(cls,'ticker', e.target.value)} style={{ width:'100%', padding:'0.25rem', border:'1px solid #d1d5db', borderRadius:'0.25rem' }} />
+                </td>
+                <td style={{ padding:'0.5rem' }}>
+                  <input value={info.name} onChange={e => updateBenchmark(cls,'name', e.target.value)} style={{ width:'100%', padding:'0.25rem', border:'1px solid #d1d5db', borderRadius:'0.25rem' }} />
+                </td>
+                <td style={{ padding:'0.5rem' }}>
+                  <button onClick={() => { const copy={...assetClassBenchmarks}; delete copy[cls]; setAssetClassBenchmarks(copy); setConfig(copy); commitConfig(recommendedFunds, copy); }} style={{ padding:'0.25rem', background:'#ef4444', color:'white', border:'none', borderRadius:'0.25rem', cursor:'pointer' }}>
+                    <Trash2 size={14} />
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};
+
+export default AdminPanel;

--- a/src/components/__tests__/AdminPanel.addFund.test.jsx
+++ b/src/components/__tests__/AdminPanel.addFund.test.jsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import userEvent from '@testing-library/user-event';
+import AdminPanel from '../AdminPanel.jsx';
+
+function setup() {
+  const setFunds = jest.fn();
+  render(
+    <AdminPanel
+      recommendedFunds={[]}
+      setRecommendedFunds={setFunds}
+      assetClassBenchmarks={{ Equity: { ticker: 'SPY', name: 'S&P 500' } }}
+      setAssetClassBenchmarks={() => {}}
+      setConfig={() => {}}
+    />
+  );
+  return { setFunds };
+}
+
+test('bad ticker shows error then success toast on valid input', async () => {
+  setup();
+  await userEvent.type(screen.getByLabelText(/Ticker/i), 'bad!');
+  await userEvent.type(screen.getByLabelText(/Name/i), 'Test Fund');
+  await userEvent.type(screen.getByLabelText(/Asset Class/i), 'Equity');
+  await userEvent.click(screen.getByRole('button', { name: /add fund/i }));
+  expect(await screen.findByRole('alert')).toHaveTextContent(/invalid ticker/i);
+
+  await userEvent.clear(screen.getByLabelText(/Ticker/i));
+  await userEvent.type(screen.getByLabelText(/Ticker/i), 'GOOD');
+  await userEvent.click(screen.getByRole('button', { name: /add fund/i }));
+  expect(await screen.findByTestId('toast')).toHaveTextContent(/Fund added/i);
+});

--- a/src/data/validators.js
+++ b/src/data/validators.js
@@ -1,0 +1,1 @@
+export const isValidTicker = t => /^[A-Z0-9]{1,5}$/.test(t.trim());


### PR DESCRIPTION
## Summary
- extract AdminPanel from `App` and implement form with `react-hook-form`
- add inline validation errors and success toast
- persist configuration after CRUD mutations and show modal on failure
- add helper `isValidTicker`
- add unit test for AdminPanel add fund behavior
- install `react-hook-form`

## Testing
- `CI=true npm test --silent -- -w=0`

------
https://chatgpt.com/codex/tasks/task_e_685ab6412b9c83298712522efd8133e9