### PR TITLE
Add benchmark lead analysis

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -21,7 +21,7 @@ import ClassView from './components/ClassView.jsx';
 import AdminPanel from './components/AdminPanel.jsx';
 import AppContext from './context/AppContext.jsx';
 import TagFilterBar from './components/Filters/TagFilterBar.jsx';
-
+import AnalysisView from './components/Views/AnalysisView.jsx';
 // Score badge component for visual display
 const ScoreBadge = ({ score, size = 'normal' }) => {
   const color = getScoreColor(score);
@@ -539,121 +539,16 @@ const App = () => {
 
       {/* Analysis Tab */}
       {activeTab === 'analysis' && (
-        <div>
-          <h2 style={{ fontSize: '1.5rem', fontWeight: 'bold', marginBottom: '1rem' }}>
-            Fund Analysis & Review Candidates
-          </h2>
-          
-          {reviewCandidates.length > 0 ? (
-            <>
-              <div style={{ 
-                marginBottom: '1rem', 
-                padding: '1rem', 
-                backgroundColor: '#fef3c7', 
-                borderRadius: '0.5rem',
-                border: '1px solid #fbbf24'
-              }}>
-                <p style={{ fontWeight: '500' }}>
-                  <AlertCircle size={20} style={{ display: 'inline', verticalAlign: 'text-bottom', marginRight: '0.5rem' }} />
-                  {reviewCandidates.length} funds flagged for review
-                </p>
-              </div>
-              
-              <div style={{ display: 'grid', gap: '1rem' }}>
-                {reviewCandidates.map((fund, i) => (
-                  <div 
-                    key={i} 
-                    style={{ 
-                      padding: '1rem', 
-                      border: '1px solid #e5e7eb',
-                      borderRadius: '0.5rem',
-                      backgroundColor: fund.isRecommended ? '#fef2f2' : 'white'
-                    }}
-                  >
-                    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'start', marginBottom: '0.5rem' }}>
-                      <div>
-                        <h3 style={{ fontWeight: 'bold', fontSize: '1.125rem' }}>
-                          {fund['Fund Name']}
-                        </h3>
-                        <p style={{ color: '#6b7280', fontSize: '0.875rem' }}>
-                          {fund.Symbol} | {fund.assetClass}
-                          {fund.isRecommended && (
-                            <span style={{ 
-                              marginLeft: '0.5rem',
-                              color: '#dc2626',
-                              fontWeight: 'bold'
-                            }}>
-                              (Recommended Fund)
-                            </span>
-                          )}
-                        </p>
-                      </div>
-                      <ScoreBadge score={fund.scores?.final || 0} size="large" />
-                    </div>
-                    
-                    <div style={{ marginTop: '0.75rem' }}>
-                      <strong style={{ fontSize: '0.875rem' }}>Review Reasons:</strong>
-                      <ul style={{ marginTop: '0.25rem', marginLeft: '1.5rem', fontSize: '0.875rem', color: '#dc2626' }}>
-                        {fund.reviewReasons.map((reason, j) => (
-                          <li key={j}>{reason}</li>
-                        ))}
-                      </ul>
-                    </div>
-                    
-                    <div style={{ 
-                      marginTop: '0.75rem', 
-                      display: 'grid', 
-                      gridTemplateColumns: 'repeat(auto-fit, minmax(120px, 1fr))',
-                      gap: '0.5rem',
-                      fontSize: '0.875rem'
-                    }}>
-                      <div>
-                        <span style={{ color: '#6b7280' }}>1Y Return:</span>{' '}
-                        <strong>{fmtPct(fund.oneYear ?? fund['1 Year'])}</strong>
-                      </div>
-                      <div>
-                        <span style={{ color: '#6b7280' }}>Sharpe:</span>{' '}
-                        <strong>{fmtNumber(fund.sharpe ?? fund['Sharpe Ratio'])}</strong>
-                      </div>
-                      <div>
-                        <span style={{ color: '#6b7280' }}>Expense:</span>{' '}
-                        <strong>{fmtPct(fund.expense ?? fund['Net Expense Ratio'])}</strong>
-                      </div>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </>
-          ) : scoredFundData.length > 0 ? (
-            <div style={{ 
-              textAlign: 'center', 
-              padding: '3rem', 
-              backgroundColor: '#f0fdf4', 
-              borderRadius: '0.5rem',
-              color: '#16a34a' 
-            }}>
-              <Award size={48} style={{ margin: '0 auto 1rem' }} />
-              <p style={{ fontSize: '1.125rem', fontWeight: '500' }}>
-                All funds are performing within acceptable parameters!
-              </p>
-              <p style={{ color: '#6b7280', marginTop: '0.5rem' }}>
-                No funds currently flagged for review.
-              </p>
-            </div>
-          ) : (
-            <div style={{ 
-              textAlign: 'center', 
-              padding: '3rem', 
-              backgroundColor: '#f9fafb', 
-              borderRadius: '0.5rem',
-              color: '#6b7280' 
-            }}>
-              <AlertCircle size={48} style={{ margin: '0 auto 1rem', opacity: 0.3 }} />
-              <p>Upload fund performance data to see analysis</p>
-            </div>
-          )}
-        </div>
+        <AnalysisView
+          funds={scoredFundData}
+          reviewCandidates={reviewCandidates}
+          onSelectClass={ac => {
+            setSelectedClassView(ac);
+            setActiveTab('class');
+          }}
+        />
       )}
+
 
       {/* History Tab */}
       {activeTab === 'history' && (

--- a/src/__tests__/AnalysisView.integration.test.jsx
+++ b/src/__tests__/AnalysisView.integration.test.jsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import AnalysisView from '../components/Views/AnalysisView.jsx';
+
+const sampleFunds = [
+  { assetClass: 'Large Cap', Symbol: 'IWF', isBenchmark: true, scores: { final: 60 } },
+  { assetClass: 'Large Cap', Symbol: 'A', isBenchmark: false, scores: { final: 50 } },
+  { assetClass: 'Large Cap', Symbol: 'B', isBenchmark: false, scores: { final: 48 } },
+  { assetClass: 'Large Cap', Symbol: 'C', isBenchmark: false, scores: { final: 52 } },
+  { assetClass: 'Large Cap', Symbol: 'D', isBenchmark: false, scores: { final: 55 } },
+  { assetClass: 'Bond', Symbol: 'AGG', isBenchmark: true, scores: { final: 70 } },
+  { assetClass: 'Bond', Symbol: 'E', isBenchmark: false, scores: { final: 65 } },
+  { assetClass: 'Bond', Symbol: 'F', isBenchmark: false, scores: { final: 66 } },
+  { assetClass: 'Bond', Symbol: 'G', isBenchmark: false, scores: { final: 64 } },
+  { assetClass: 'Bond', Symbol: 'H', isBenchmark: false, scores: { final: 50 } }
+];
+
+const reviewCandidates = [
+  { 'Fund Name': 'Test Fund', Symbol: 'A', assetClass: 'Large Cap', scores: { final: 45 }, reviewReasons: ['Low score'] }
+];
+
+test('gap filter and row click work', async () => {
+  const handler = jest.fn();
+  render(<AnalysisView funds={sampleFunds} reviewCandidates={reviewCandidates} onSelectClass={handler} />);
+
+  expect(screen.getAllByRole('row')).toHaveLength(3); // header + 2 rows
+
+  const input = screen.getByLabelText(/Gap/);
+  await userEvent.clear(input);
+  await userEvent.type(input, '7');
+
+  expect(screen.getAllByRole('row')).toHaveLength(2); // header + 1 row
+
+  await userEvent.click(screen.getByText('Large Cap'));
+  expect(handler).toHaveBeenCalledWith('Large Cap');
+});
+

--- a/src/__tests__/benchmarkLead.test.js
+++ b/src/__tests__/benchmarkLead.test.js
@@ -1,0 +1,32 @@
+import { getClassesWhereBenchmarkLeads } from '../selectors/benchmarkLead';
+
+describe('getClassesWhereBenchmarkLeads', () => {
+  const sample = [
+    { assetClass: 'Large Cap', Symbol: 'IWF', isBenchmark: true, scores: { final: 80 } },
+    { assetClass: 'Large Cap', Symbol: 'AAA', isBenchmark: false, scores: { final: 50 } },
+    { assetClass: 'Large Cap', Symbol: 'BBB', isBenchmark: false, scores: { final: 60 } },
+    { assetClass: 'Large Cap', Symbol: 'CCC', isBenchmark: false, scores: { final: 55 } },
+    { assetClass: 'Large Cap', Symbol: 'DDD', isBenchmark: false, scores: { final: 70 } },
+    { assetClass: 'Small Cap', Symbol: 'IWM', isBenchmark: true, scores: { final: 55 } },
+    { assetClass: 'Small Cap', Symbol: 'EEE', isBenchmark: false, scores: { final: 50 } },
+    { assetClass: 'Small Cap', Symbol: 'FFF', isBenchmark: false, scores: { final: 48 } }
+  ];
+
+  test('detects benchmark lead with default threshold', () => {
+    const result = getClassesWhereBenchmarkLeads(sample, 10);
+    expect(result).toEqual([
+      {
+        assetClass: 'Large Cap',
+        benchmarkSymbol: 'IWF',
+        benchmarkScore: 80,
+        medianPeerScore: 57.5,
+        gap: 22.5
+      }
+    ]);
+  });
+
+  test('respects custom threshold', () => {
+    const result = getClassesWhereBenchmarkLeads(sample, 25);
+    expect(result).toEqual([]);
+  });
+});

--- a/src/components/Views/AnalysisView.jsx
+++ b/src/components/Views/AnalysisView.jsx
@@ -1,0 +1,133 @@
+import React, { useState, useMemo } from 'react';
+import { getScoreColor, getScoreLabel } from '../../utils/scoreTags';
+import { fmtPct, fmtNumber } from '../../utils/formatters';
+import { getClassesWhereBenchmarkLeads } from '../../selectors/benchmarkLead';
+
+const ScoreBadge = ({ score }) => {
+  const color = getScoreColor(score);
+  const label = getScoreLabel(score);
+  return (
+    <span
+      className="inline-flex items-center rounded-full px-2 py-1 text-sm font-medium"
+      style={{ backgroundColor: `${color}20`, color, border: `1px solid ${color}50` }}
+    >
+      {Number(score).toFixed(1)} - {label}
+    </span>
+  );
+};
+
+const AnalysisView = ({ funds = [], reviewCandidates = [], onSelectClass }) => {
+  const [gap, setGap] = useState(5);
+  const [sort, setSort] = useState({ key: 'gap', dir: 'desc', numeric: true });
+
+  const leadData = useMemo(
+    () => getClassesWhereBenchmarkLeads(funds, Number(gap)),
+    [funds, gap]
+  );
+
+  const sorted = useMemo(() => {
+    const data = [...leadData];
+    data.sort((a, b) => {
+      const av = a[sort.key];
+      const bv = b[sort.key];
+      if (sort.numeric) {
+        return sort.dir === 'asc' ? av - bv : bv - av;
+      }
+      const as = String(av).toUpperCase();
+      const bs = String(bv).toUpperCase();
+      if (as < bs) return sort.dir === 'asc' ? -1 : 1;
+      if (as > bs) return sort.dir === 'asc' ? 1 : -1;
+      return 0;
+    });
+    return data;
+  }, [leadData, sort]);
+
+  const handleSort = (key, numeric) => {
+    let dir = 'asc';
+    if (sort.key === key) {
+      dir = sort.dir === 'asc' ? 'desc' : 'asc';
+    } else {
+      dir = numeric ? 'desc' : 'asc';
+    }
+    setSort({ key, dir, numeric });
+  };
+
+  return (
+    <div>
+      <h2 className="text-xl font-bold mb-4">Benchmark Leaders</h2>
+      <div className="flex items-center gap-2 mb-4">
+        <label className="font-medium" htmlFor="gapInput">Gap ≥</label>
+        <input
+          id="gapInput"
+          type="number"
+          className="border rounded px-2 py-1 w-20"
+          value={gap}
+          onChange={e => setGap(Number(e.target.value))}
+        />
+      </div>
+      <div className="overflow-x-auto mb-6">
+        <table className="min-w-full border-collapse" role="table">
+          <thead>
+            <tr className="border-b">
+              <th className="p-2 text-left cursor-pointer" onClick={() => handleSort('assetClass', false)}>Asset Class</th>
+              <th className="p-2 text-left cursor-pointer" onClick={() => handleSort('benchmarkSymbol', false)}>Benchmark</th>
+              <th className="p-2 text-right cursor-pointer" onClick={() => handleSort('benchmarkScore', true)}>Bench. Score</th>
+              <th className="p-2 text-right cursor-pointer" onClick={() => handleSort('medianPeerScore', true)}>Median Peer</th>
+              <th className="p-2 text-right cursor-pointer" onClick={() => handleSort('gap', true)}>Gap</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sorted.map(row => (
+              <tr
+                key={row.assetClass}
+                className="border-b cursor-pointer hover:bg-gray-50"
+                onClick={() => onSelectClass && onSelectClass(row.assetClass)}
+              >
+                <td className="p-2">{row.assetClass}</td>
+                <td className="p-2">{row.benchmarkSymbol}</td>
+                <td className="p-2 text-right">{row.benchmarkScore.toFixed(1)}</td>
+                <td className="p-2 text-right">{row.medianPeerScore.toFixed(1)}</td>
+                <td className="p-2 text-right">+{row.gap.toFixed(1)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      {reviewCandidates.length > 0 && (
+        <details>
+          <summary className="cursor-pointer font-medium mb-2">Flagged Funds ({reviewCandidates.length})</summary>
+          <div className="grid gap-4 mt-2">
+            {reviewCandidates.map((fund, i) => (
+              <div key={i} className={`border rounded p-4 ${fund.isRecommended ? 'bg-red-50' : 'bg-white'}`}>
+                <div className="flex justify-between mb-2">
+                  <div>
+                    <h3 className="font-bold text-lg">{fund['Fund Name']}</h3>
+                    <p className="text-sm text-gray-600">{fund.Symbol} | {fund.assetClass}{fund.isRecommended && (
+                      <span className="ml-1 text-red-600 font-bold">(Recommended Fund)</span>
+                    )}</p>
+                  </div>
+                  <ScoreBadge score={fund.scores?.final || 0} />
+                </div>
+                <div>
+                  <strong className="text-sm">Review Reasons:</strong>
+                  <ul className="list-disc ml-6 text-sm text-red-600 mt-1">
+                    {fund.reviewReasons.map((reason, j) => (
+                      <li key={j}>{reason}</li>
+                    ))}
+                  </ul>
+                </div>
+                <div className="grid grid-cols-3 gap-2 text-sm mt-2">
+                  <div><span className="text-gray-600">1Y Return:</span> <strong>{fmtPct(fund.oneYear ?? fund['1 Year'])}</strong></div>
+                  <div><span className="text-gray-600">Sharpe:</span> <strong>{fmtNumber(fund.sharpe ?? fund['Sharpe Ratio'])}</strong></div>
+                  <div><span className="text-gray-600">Expense:</span> <strong>{fmtPct(fund.expense ?? fund['Net Expense Ratio'])}</strong></div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </details>
+      )}
+    </div>
+  );
+};
+
+export default AnalysisView;

--- a/src/selectors/benchmarkLead.js
+++ b/src/selectors/benchmarkLead.js
@@ -1,0 +1,45 @@
+export function getClassesWhereBenchmarkLeads(funds, gapThreshold = 5) {
+  if (!Array.isArray(funds)) return [];
+  const byClass = {};
+  funds.forEach(f => {
+    const cls = f.assetClass;
+    if (!cls) return;
+    if (!byClass[cls]) byClass[cls] = [];
+    byClass[cls].push(f);
+  });
+
+  const median = values => {
+    const nums = values.filter(v => v != null && !isNaN(v)).sort((a, b) => a - b);
+    if (nums.length === 0) return 0;
+    const mid = Math.floor(nums.length / 2);
+    if (nums.length % 2) return nums[mid];
+    return (nums[mid - 1] + nums[mid]) / 2;
+  };
+
+  const results = [];
+
+  Object.entries(byClass).forEach(([assetClass, items]) => {
+    const benchmark = items.find(f => f.isBenchmark && f.scores);
+    const peers = items.filter(f => !f.isBenchmark && f.scores);
+    if (!benchmark || peers.length < 3) return;
+
+    const peerScores = peers.map(p => p.scores.final);
+    if (peerScores.length === 0) return;
+
+    const medianPeerScore = median(peerScores);
+    const benchmarkScore = benchmark.scores.final;
+    const gap = benchmarkScore - medianPeerScore;
+    if (gap >= gapThreshold) {
+      results.push({
+        assetClass,
+        benchmarkSymbol: benchmark.Symbol,
+        benchmarkScore: Math.round(benchmarkScore * 10) / 10,
+        medianPeerScore: Math.round(medianPeerScore * 10) / 10,
+        gap: Math.round(gap * 10) / 10
+      });
+    }
+  });
+
+  return results;
+}
+


### PR DESCRIPTION
## Summary
- implement `getClassesWhereBenchmarkLeads` selector
- create `AnalysisView` component showing benchmark-leading asset classes
- hook new component into `App.jsx`
- add unit and integration tests

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685b108b5c2c8329adf1589f584937c2