### PR TITLE
Enhance Analysis tab with heat map view

### DIFF
--- a/src/__tests__/AnalysisView.integration.test.jsx
+++ b/src/__tests__/AnalysisView.integration.test.jsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
 import AnalysisView from '../components/Views/AnalysisView.jsx';
 
 const sampleFunds = [
@@ -25,11 +26,15 @@ test('gap filter and row click work', async () => {
 
   expect(screen.getAllByRole('row')).toHaveLength(3); // header + 2 rows
 
-  const input = screen.getByLabelText(/Gap/);
+  const input = screen.getByLabelText(/Bench.*Median/);
   await userEvent.clear(input);
   await userEvent.type(input, '7');
 
   expect(screen.getAllByRole('row')).toHaveLength(2); // header + 1 row
+
+  const toggle = screen.getByLabelText('toggle view');
+  await userEvent.click(toggle);
+  expect(screen.getByRole('table')).toBeInTheDocument();
 
   await userEvent.click(screen.getByText('Large Cap'));
   expect(handler).toHaveBeenCalledWith('Large Cap');

--- a/src/__tests__/HeatMapGrid.test.jsx
+++ b/src/__tests__/HeatMapGrid.test.jsx
@@ -1,0 +1,11 @@
+import { render } from '@testing-library/react';
+import HeatMapGrid from '../components/HeatMapGrid.jsx';
+
+const rows = [
+  { assetClass: 'Large Cap', benchmarkScore: 60, medianPeerScore: 50, gap: 10 }
+];
+
+test('renders heatmap snapshot', () => {
+  const { asFragment } = render(<HeatMapGrid rows={rows} onSelect={() => {}} />);
+  expect(asFragment()).toMatchSnapshot();
+});

--- a/src/__tests__/__snapshots__/HeatMapGrid.test.jsx.snap
+++ b/src/__tests__/__snapshots__/HeatMapGrid.test.jsx.snap
@@ -1,0 +1,61 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders heatmap snapshot 1`] = `
+<DocumentFragment>
+  <div
+    data-testid="heatmap"
+  >
+    <div
+      class="grid grid-cols-4 font-semibold border-b text-sm"
+      role="row"
+    >
+      <div
+        class="p-2"
+      >
+        Asset Class
+      </div>
+      <div
+        class="p-2 text-right"
+      >
+        Benchmark Score
+      </div>
+      <div
+        class="p-2 text-right"
+      >
+        Median Peer
+      </div>
+      <div
+        class="p-2 text-right"
+      >
+        Gap
+      </div>
+    </div>
+    <div
+      class="grid grid-cols-4 border-b last:border-b-0 cursor-pointer hover:bg-gray-50"
+      role="row"
+    >
+      <div
+        class="p-2"
+      >
+        Large Cap
+      </div>
+      <div
+        class="p-2 text-right"
+      >
+        60.0
+      </div>
+      <div
+        class="p-2 text-right"
+      >
+        50.0
+      </div>
+      <div
+        class="p-2 text-right bg-green-500 text-white"
+        title="60.0 vs 50.0"
+      >
+        +10.0
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/src/components/HeatMapGrid.jsx
+++ b/src/components/HeatMapGrid.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+
+const gapColor = gap => {
+  if (gap >= 10) return 'bg-green-500 text-white';
+  if (gap >= 5) return 'bg-green-300';
+  if (gap >= 0) return 'bg-slate-200';
+  return 'bg-red-300';
+};
+
+const HeatMapGrid = ({ rows = [], onSelect }) => {
+  if (!rows.length) return null;
+  return (
+    <div data-testid="heatmap">
+      <div className="grid grid-cols-4 font-semibold border-b text-sm" role="row">
+        <div className="p-2">Asset Class</div>
+        <div className="p-2 text-right">Benchmark Score</div>
+        <div className="p-2 text-right">Median Peer</div>
+        <div className="p-2 text-right">Gap</div>
+      </div>
+      {rows.map(row => (
+        <div
+          key={row.assetClass}
+          role="row"
+          className="grid grid-cols-4 border-b last:border-b-0 cursor-pointer hover:bg-gray-50"
+          onClick={() => onSelect && onSelect(row.assetClass)}
+        >
+          <div className="p-2">{row.assetClass}</div>
+          <div className="p-2 text-right">{row.benchmarkScore.toFixed(1)}</div>
+          <div className="p-2 text-right">{row.medianPeerScore.toFixed(1)}</div>
+          <div
+            className={`p-2 text-right ${gapColor(row.gap)}`}
+            title={`${row.benchmarkScore.toFixed(1)} vs ${row.medianPeerScore.toFixed(1)}`}
+          >
+            {row.gap >= 0 ? '+' : ''}{row.gap.toFixed(1)}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default HeatMapGrid;


### PR DESCRIPTION
## Summary
- add `HeatMapGrid` component for gap heat map visualization
- integrate heat map into `AnalysisView` with gap threshold input and view toggle
- auto-expand flagged funds section with a count badge
- add unit and integration tests

## Testing
- `npm install`
- `CI=true npm test -- -u`

------
https://chatgpt.com/codex/tasks/task_e_685b187433f883299eb7624214e57f93