### PR TITLE
Fix return mapping and add alpha/capture ratios

### DIFF
--- a/src/services/__tests__/parseFundFile.mappingFix.test.js
+++ b/src/services/__tests__/parseFundFile.mappingFix.test.js
@@ -1,0 +1,34 @@
+import parseFundFile from '../parseFundFile';
+
+const headers = [
+  'Symbol',
+  'Fund Name',
+  'Annualized Total Return - 3 Year (%)',
+  'Annualized Total Return - 5 Year (%)',
+  'Annualized Total Return - 10 Year (%)',
+  'Alpha (Asset Class) - 5 Year',
+  'Up Capture Ratio (Morningstar Standard) - 3 Year',
+  'Down Capture Ratio (Morningstar Standard) - 3 Year'
+];
+
+const dataRow = [
+  'AAA',
+  'Sample Fund',
+  '5.38911',
+  '5.78925',
+  '7.12345',
+  '0.34',
+  '102.5',
+  '98.7'
+];
+
+test('correctly maps annualized returns and capture ratios', async () => {
+  const result = await parseFundFile([headers, dataRow]);
+  const row = result[0];
+  expect(row['3 Year']).toBeCloseTo(5.38911);
+  expect(row['5 Year']).toBeCloseTo(5.78925);
+  expect(row['10 Year']).toBeCloseTo(7.12345);
+  expect(row.alpha5Y).toBeCloseTo(0.34);
+  expect(row.upCapture3Y).toBeCloseTo(102.5);
+  expect(row.downCapture3Y).toBeCloseTo(98.7);
+});

--- a/src/services/parseFundFile.js
+++ b/src/services/parseFundFile.js
@@ -21,30 +21,63 @@ export default async function parseFundFile(rows, options = {}) {
     if (typeof h !== 'string') return;
     const header = h.toString().trim();
     const headerLower = header.toLowerCase();
+
     if (headerLower.includes('symbol')) columnMap.Symbol = idx;
     if (headerLower.includes('product name')) columnMap['Fund Name'] = idx;
     if (headerLower === 'asset class') columnMap['Asset Class'] = idx;
+
     if (
-      (headerLower === 'ytd return' || headerLower.includes('total return - ytd')) &&
+      headerLower.includes('total return') &&
+      headerLower.includes('ytd') &&
       !headerLower.includes('category')
     )
       columnMap.YTD = idx;
+
     if (
-      (headerLower === '1 year return' || headerLower.includes('total return - 1 year')) &&
+      headerLower.includes('total return') &&
+      headerLower.includes('1') &&
+      headerLower.includes('year') &&
       !headerLower.includes('category')
     )
       columnMap['1 Year'] = idx;
-    if (headerLower.includes('3 year') && !headerLower.includes('standard deviation'))
+
+    if (
+      headerLower.includes('total return') &&
+      headerLower.includes('3') &&
+      headerLower.includes('year') &&
+      !headerLower.includes('category')
+    )
       columnMap['3 Year'] = idx;
-    if (headerLower.includes('5 year') && !headerLower.includes('standard deviation'))
+
+    if (
+      headerLower.includes('total return') &&
+      headerLower.includes('5') &&
+      headerLower.includes('year') &&
+      !headerLower.includes('category')
+    )
       columnMap['5 Year'] = idx;
-    if (headerLower.includes('10 year')) columnMap['10 Year'] = idx;
+
+    if (
+      headerLower.includes('total return') &&
+      headerLower.includes('10') &&
+      headerLower.includes('year') &&
+      !headerLower.includes('category')
+    )
+      columnMap['10 Year'] = idx;
+
     if (headerLower.includes('sharpe')) columnMap['Sharpe Ratio'] = idx;
     if (headerLower.includes('standard deviation - 3')) columnMap['StdDev3Y'] = idx;
     if (headerLower.includes('standard deviation - 5')) columnMap['Standard Deviation'] = idx;
     if (headerLower.includes('net exp')) columnMap['Net Expense Ratio'] = idx;
     if (headerLower.includes('manager tenure')) columnMap['Manager Tenure'] = idx;
     if (headerLower.includes('vehicle type') || headerLower === 'type') columnMap.type = idx;
+
+    if (headerLower.includes('alpha') && headerLower.includes('5 year'))
+      columnMap['Alpha (Asset Class) - 5 Year'] = idx;
+    if (headerLower.includes('up capture') && headerLower.includes('3 year'))
+      columnMap['Up Capture Ratio (Morningstar Standard) - 3 Year'] = idx;
+    if (headerLower.includes('down capture') && headerLower.includes('3 year'))
+      columnMap['Down Capture Ratio (Morningstar Standard) - 3 Year'] = idx;
   });
 
   const cleanNumber = val => {
@@ -110,6 +143,13 @@ export default async function parseFundFile(rows, options = {}) {
     const sharpe = cleanNumber(f['Sharpe Ratio']);
     const stdDev3y = cleanNumber(f.StdDev3Y);
     const stdDev5y = cleanNumber(f['Standard Deviation'] ?? f.StdDev5Y);
+    const alpha5Y = cleanNumber(f['Alpha (Asset Class) - 5 Year']);
+    const upCapture3Y = cleanNumber(
+      f['Up Capture Ratio (Morningstar Standard) - 3 Year']
+    );
+    const downCapture3Y = cleanNumber(
+      f['Down Capture Ratio (Morningstar Standard) - 3 Year']
+    );
     const expense = cleanNumber(f['Net Expense Ratio']);
 
     const row = {
@@ -125,6 +165,9 @@ export default async function parseFundFile(rows, options = {}) {
       'Sharpe Ratio': sharpe,
       '3Y Std Dev': stdDev3y,
       '5Y Std Dev': stdDev5y,
+      'Alpha (Asset Class) - 5 Year': alpha5Y,
+      'Up Capture Ratio (Morningstar Standard) - 3 Year': upCapture3Y,
+      'Down Capture Ratio (Morningstar Standard) - 3 Year': downCapture3Y,
       'Net Expense Ratio': expense,
       'Manager Tenure': f['Manager Tenure'],
       Type: f.type || '',
@@ -136,6 +179,9 @@ export default async function parseFundFile(rows, options = {}) {
       sharpe,
       stdDev3y,
       stdDev5y,
+      alpha5Y,
+      upCapture3Y,
+      downCapture3Y,
       expense,
     };
     // keep header-style copy for legacy filters/exports


### PR DESCRIPTION
## Summary
- refine header matching in `parseFundFile.js` to avoid misaligned metrics
- add parsing for Alpha and Capture Ratio columns
- expose `alpha5Y`, `upCapture3Y`, `downCapture3Y` on fund rows
- add regression test for new mapping

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685bf98e85a08329a26b26dbededa3d1