### PR TITLE
Add TypeScript fund file parser

### DIFF
--- a/scripts/check-parser.ts
+++ b/scripts/check-parser.ts
@@ -1,0 +1,11 @@
+import { parseFundFile } from '../src/utils/parseFundFile'
+import fs from 'fs/promises'
+
+;(async () => {
+  const file = new File(
+    [await fs.readFile('data/historical/June2024_FundPerformance.csv')],
+    'June2024_FundPerformance.csv'
+  )
+  const snap = await parseFundFile(file)
+  console.log(`${snap.rows.length} rows parsed OK`)
+})()

--- a/src/utils/__tests__/parseFundFile.test.ts
+++ b/src/utils/__tests__/parseFundFile.test.ts
@@ -1,0 +1,21 @@
+import { parseFundFile } from '../parseFundFile'
+import fs from 'fs/promises'
+
+describe('parseFundFile', () => {
+  it('parses Raymond James sample', async () => {
+    const buf = await fs.readFile('data/Fund_Performance_Data.csv')
+    const file = new File([buf], 'Fund_Performance_Data.csv')
+    const snap = await parseFundFile(file)
+    expect(snap.rows.length).toBeGreaterThan(100)
+    const sample = snap.rows[0]
+    expect(sample).toHaveProperty('symbol')
+    expect(sample).toHaveProperty('ytdReturn')
+  })
+
+  it('parses YCharts sample', async () => {
+    const buf = await fs.readFile('data/historical/June2024_FundPerformance.csv')
+    const file = new File([buf], 'June2024_FundPerformance.csv')
+    const snap = await parseFundFile(file)
+    expect(snap.rows.length).toBeGreaterThan(100)
+  })
+})

--- a/src/utils/parseFundFile.ts
+++ b/src/utils/parseFundFile.ts
@@ -1,0 +1,200 @@
+// src/utils/parseFundFile.ts
+import * as XLSX from 'xlsx'
+import { createHash } from 'crypto'
+import { recommendedFunds } from '../data/config.js'
+
+export const COLUMN_MAP: Record<string, keyof NormalisedRow> = {
+  'Symbol': 'symbol',
+  'Symbol/CUSIP': 'symbol',
+  'Product Name': 'productName',
+  'Total Return - YTD (%)': 'ytdReturn',
+  'Total Return - 1 Year (%)': 'oneYearReturn',
+  'Total Return - 3 Year (%)': 'threeYearReturn',
+  'Total Return - 5 Year (%)': 'fiveYearReturn',
+  'Total Return - 10 Year (%)': 'tenYearReturn',
+  'Annualized Total Return - 3 Year (%)': 'threeYearReturn',
+  'Annualized Total Return - 5 Year (%)': 'fiveYearReturn',
+  'Annualized Total Return - 10 Year (%)': 'tenYearReturn',
+  'YTD Return (%)': 'ytdReturn',
+  'Return 1 Year (%)': 'oneYearReturn',
+  'Return 3 Year (%)': 'threeYearReturn',
+  'Return 5 Year (%)': 'fiveYearReturn',
+  'Return 10 Year (%)': 'tenYearReturn',
+  'Sharpe Ratio (3 Year)': 'sharpe3y',
+  'Sharpe Ratio - 3 Year': 'sharpe3y',
+  'Sharpe Ratio 3Y': 'sharpe3y',
+  'Standard Deviation (3 Year) (%)': 'stdDev3y',
+  'Standard Deviation - 3 Year': 'stdDev3y',
+  'Std Dev 3Y (%)': 'stdDev3y',
+  'Standard Deviation (5 Year) (%)': 'stdDev5y',
+  'Standard Deviation - 5 Year': 'stdDev5y',
+  'Std Dev 5Y (%)': 'stdDev5y',
+  'Alpha (Asset Class) – 5 Year': 'alpha5y',
+  'Alpha (Asset Class) - 5 Year': 'alpha5y',
+  'Alpha 5Y (%)': 'alpha5y',
+  'Net Expense Ratio (%)': 'netExpenseRatio',
+  'Net Exp Ratio (%)': 'netExpenseRatio',
+  'Expense Ratio Net (%)': 'netExpenseRatio',
+  'Manager Tenure (Years)': 'managerTenure',
+  'Longest Manager Tenure (Years)': 'managerTenure',
+  'Manager Tenure (Yrs)': 'managerTenure',
+  'Up Capture Ratio 3Y (%)': 'upCapture3y',
+  'Up Capture Ratio (Morningstar Standard) - 3 Year': 'upCapture3y',
+  'Down Capture Ratio 3Y (%)': 'downCapture3y',
+  'Down Capture Ratio (Morningstar Standard) - 3 Year': 'downCapture3y',
+  'Category Rank (%) Total Return – YTD': 'rankYtd',
+  'Category Rank (%) Total Return  YTD': 'rankYtd'
+}
+
+export interface NormalisedRow {
+  symbol: string
+  productName: string | null
+  ytdReturn: number | null
+  oneYearReturn: number | null
+  threeYearReturn: number | null
+  fiveYearReturn: number | null
+  tenYearReturn: number | null
+  sharpe3y: number | null
+  stdDev3y: number | null
+  stdDev5y: number | null
+  alpha5y: number | null
+  netExpenseRatio: number | null
+  managerTenure: number | null
+  upCapture3y?: number | null
+  downCapture3y?: number | null
+  rankYtd?: number | null
+}
+
+export interface ParsedSnapshot {
+  id?: string
+  rows: NormalisedRow[]
+  source: string
+  checksum: string
+}
+
+const REQUIRED = [
+  'symbol',
+  'ytdReturn',
+  'oneYearReturn',
+  'threeYearReturn',
+  'fiveYearReturn',
+  'tenYearReturn',
+  'sharpe3y',
+  'netExpenseRatio',
+  'managerTenure',
+  'alpha5y'
+] as const
+
+function parseNumber(val: any): number | null {
+  if (val == null || val === '') return null
+  if (typeof val === 'string') val = val.replace(/[%,]/g, '').trim()
+  const n = parseFloat(val)
+  return Number.isNaN(n) ? null : n
+}
+
+async function readFileAsRows(file: File): Promise<any[][]> {
+  if (file.name.toLowerCase().endsWith('.csv')) {
+    const text = await file.text()
+    const wb = XLSX.read(text, { type: 'string' })
+    const sheet = wb.Sheets[wb.SheetNames[0]]
+    return XLSX.utils.sheet_to_json(sheet, { header: 1 }) as any[][]
+  }
+  const buf = await file.arrayBuffer()
+  const wb = XLSX.read(new Uint8Array(buf), { type: 'array' })
+  const sheet = wb.Sheets[wb.SheetNames[0]]
+  return XLSX.utils.sheet_to_json(sheet, { header: 1 }) as any[][]
+}
+
+async function sha1(file: File): Promise<string> {
+  const buf = await file.arrayBuffer()
+  return createHash('sha1').update(Buffer.from(buf)).digest('hex')
+}
+
+export async function parseFundFile(
+  file: File,
+  columnMap = COLUMN_MAP
+): Promise<ParsedSnapshot> {
+  const rows = await readFileAsRows(file)
+  const headerIndex = rows.findIndex(r =>
+    r.some(c => typeof c === 'string' && c.toLowerCase().includes('symbol'))
+  )
+  if (headerIndex === -1) throw new Error('Header row not found')
+  const headers = rows[headerIndex].map(h => (h ? h.toString().trim() : ''))
+  const map: Record<number, keyof NormalisedRow> = {}
+  headers.forEach((h, i) => {
+    const key = columnMap[h]
+    if (key) map[i] = key
+  })
+  const columnsPresent = new Set(Object.values(map))
+  REQUIRED.forEach(req => {
+    if (!columnsPresent.has(req as keyof NormalisedRow)) {
+      throw new Error(`Missing required column: ${req}`)
+    }
+  })
+  if (!columnsPresent.has('stdDev3y') && !columnsPresent.has('stdDev5y')) {
+    throw new Error('Missing required column: stdDev3y or stdDev5y')
+  }
+  const dataRows = rows.slice(headerIndex + 1)
+  const list: NormalisedRow[] = []
+  for (const row of dataRows) {
+    if (!row || row.every(v => v == null || String(v).trim() === '')) continue
+    const obj: any = {
+      symbol: '',
+      productName: null,
+      ytdReturn: null,
+      oneYearReturn: null,
+      threeYearReturn: null,
+      fiveYearReturn: null,
+      tenYearReturn: null,
+      sharpe3y: null,
+      stdDev3y: null,
+      stdDev5y: null,
+      alpha5y: null,
+      netExpenseRatio: null,
+      managerTenure: null,
+      upCapture3y: null,
+      downCapture3y: null,
+      rankYtd: null
+    }
+    for (const [idxStr, key] of Object.entries(map)) {
+      const idx = Number(idxStr)
+      const val = row[idx]
+      if (key === 'symbol') {
+        obj.symbol = (val ?? '').toString().trim().toUpperCase()
+      } else if (key === 'productName') {
+        obj.productName = val ? String(val).trim() : null
+      } else if (
+        key === 'upCapture3y' ||
+        key === 'downCapture3y' ||
+        key === 'rankYtd' ||
+        key === 'ytdReturn' ||
+        key === 'oneYearReturn' ||
+        key === 'threeYearReturn' ||
+        key === 'fiveYearReturn' ||
+        key === 'tenYearReturn' ||
+        key === 'sharpe3y' ||
+        key === 'stdDev3y' ||
+        key === 'stdDev5y' ||
+        key === 'alpha5y' ||
+        key === 'netExpenseRatio' ||
+        key === 'managerTenure'
+      ) {
+        obj[key] = parseNumber(val)
+      } else {
+        obj[key] = val
+      }
+    }
+    const rec = recommendedFunds.find(r => r.symbol.toUpperCase() === obj.symbol)
+    if (rec) obj.productName = rec.name
+    if (obj.productName === undefined) obj.productName = null
+    list.push(obj as NormalisedRow)
+  }
+  return {
+    id: undefined,
+    rows: list,
+    source: file.name,
+    checksum: await sha1(file)
+  }
+}
+
+export default parseFundFile

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "allowJs": true,
+    "checkJs": false,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "jsx": "react-jsx",
+    "lib": ["es2020", "dom"],
+    "types": ["node", "jest"]
+  },
+  "include": ["src/**/*", "scripts/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add a new TypeScript parser that accepts Raymond James and YCharts files
- create sanity script and Jest tests
- configure basic tsconfig for compilation

## Testing
- `npm run lint` *(fails: Missing script)*
- `npx tsc --noEmit`
- `npx tsx scripts/check-parser.ts`

------
https://chatgpt.com/codex/tasks/task_e_685d75f9a1a08329adcefbd22a4c74b6