### PR TITLE
Add snapshot Dexie store

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,9 @@
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^13.5.0",
+        "dexie": "^4.0.11",
         "esm": "^3.2.25",
+        "fake-indexeddb": "^6.0.1",
         "jspdf": "^2.5.1",
         "jspdf-autotable": "^3.5.25",
         "lucide-react": "^0.517.0",
@@ -29,6 +31,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.29.0",
+        "@types/jest": "^30.0.0",
         "eslint": "^8.57.1",
         "eslint-plugin-react": "^7.37.5",
         "globals": "^16.2.0"
@@ -3116,6 +3119,16 @@
         }
       }
     },
+    "node_modules/@jest/diff-sequences": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.0.1.tgz",
+      "integrity": "sha512-n5H8QLDJ47QqbCNn5SuFjCRDrOLEZ0h8vAHCK5RL9Ls7Xa8AQLa/YxAc9UjFqoEDM48muwtBGjtMY5cr0PLDCw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/@jest/environment": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-27.5.1.tgz",
@@ -3129,6 +3142,19 @@
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@jest/expect-utils": {
+      "version": "30.0.3",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.0.3.tgz",
+      "integrity": "sha512-SMtBvf2sfX2agcT0dA9pXwcUrKvOSDqBY4e4iRfT+Hya33XzV35YVg+98YQFErVGA/VR1Gto5Y2+A6G9LSQ3Yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.0.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/fake-timers": {
@@ -3148,6 +3174,16 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
+    "node_modules/@jest/get-type": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.0.1.tgz",
+      "integrity": "sha512-AyYdemXCptSRFirI5EPazNxyPwAL0jXt3zceFjaj8NFiKP9pOi0bfXonf6qkf82z2t3QWPeLCWWw4stPBzctLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/@jest/globals": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-27.5.1.tgz",
@@ -3160,6 +3196,30 @@
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@jest/pattern": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.0.1.tgz",
+      "integrity": "sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-regex-util": "30.0.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/pattern/node_modules/jest-regex-util": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.1.tgz",
+      "integrity": "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/reporters": {
@@ -4264,6 +4324,234 @@
       "dependencies": {
         "@types/istanbul-lib-report": "*"
       }
+    },
+    "node_modules/@types/jest": {
+      "version": "30.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-30.0.0.tgz",
+      "integrity": "sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^30.0.0",
+        "pretty-format": "^30.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@jest/schemas": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.1.tgz",
+      "integrity": "sha512-+g/1TKjFuGrf1Hh0QPCv0gISwBxJ+MQSNXmG9zjHy7BmFhtoJ9fdNhWJp3qUKRi93AOZHXtdxZgJ1vAtz6z65w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@jest/types": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.0.1.tgz",
+      "integrity": "sha512-HGwoYRVF0QSKJu1ZQX0o5ZrUrrhj0aOOFA8hXrumD7SIzjouevhawbTjmXdwOmURdGluU9DM/XvGm3NyFoiQjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.0.1",
+        "@jest/schemas": "30.0.1",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@sinclair/typebox": {
+      "version": "0.34.37",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.37.tgz",
+      "integrity": "sha512-2TRuQVgQYfy+EzHRTIvkhv2ADEouJ2xNS/Vq+W5EuuewBdOrvATvljZTxHWZSTYr2sTjTHpGvucaGAt67S2akw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/jest/node_modules/@types/yargs": {
+      "version": "17.0.33",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
+      "integrity": "sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/jest/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@types/jest/node_modules/ci-info": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.2.0.tgz",
+      "integrity": "sha512-cYY9mypksY8NRqgDB1XD1RiJL338v/551niynFTGkZOO2LHuB2OmOYxDIe/ttN9AHwrqdum1360G3ald0W9kCg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@types/jest/node_modules/expect": {
+      "version": "30.0.3",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-30.0.3.tgz",
+      "integrity": "sha512-HXg6NvK35/cSYZCUKAtmlgCFyqKM4frEPbzrav5hRqb0GMz0E0lS5hfzYjSaiaE5ysnp/qI2aeZkeyeIAOeXzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "30.0.3",
+        "@jest/get-type": "30.0.1",
+        "jest-matcher-utils": "30.0.3",
+        "jest-message-util": "30.0.2",
+        "jest-mock": "30.0.2",
+        "jest-util": "30.0.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-diff": {
+      "version": "30.0.3",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.0.3.tgz",
+      "integrity": "sha512-Q1TAV0cUcBTic57SVnk/mug0/ASyAqtSIOkr7RAlxx97llRYsM74+E8N5WdGJUlwCKwgxPAkVjKh653h1+HA9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/diff-sequences": "30.0.1",
+        "@jest/get-type": "30.0.1",
+        "chalk": "^4.1.2",
+        "pretty-format": "30.0.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-matcher-utils": {
+      "version": "30.0.3",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.0.3.tgz",
+      "integrity": "sha512-hMpVFGFOhYmIIRGJ0HgM9htC5qUiJ00famcc9sRFchJJiLZbbVKrAztcgE6VnXLRxA3XZ0bvNA7hQWh3oHXo/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.0.1",
+        "chalk": "^4.1.2",
+        "jest-diff": "30.0.3",
+        "pretty-format": "30.0.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-message-util": {
+      "version": "30.0.2",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.0.2.tgz",
+      "integrity": "sha512-vXywcxmr0SsKXF/bAD7t7nMamRvPuJkras00gqYeB1V0WllxZrbZ0paRr3XqpFU2sYYjD0qAaG2fRyn/CGZ0aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@jest/types": "30.0.1",
+        "@types/stack-utils": "^2.0.3",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "micromatch": "^4.0.8",
+        "pretty-format": "30.0.2",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-mock": {
+      "version": "30.0.2",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.0.2.tgz",
+      "integrity": "sha512-PnZOHmqup/9cT/y+pXIVbbi8ID6U1XHRmbvR7MvUy4SLqhCbwpkmXhLbsWbGewHrV5x/1bF7YDjs+x24/QSvFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.0.1",
+        "@types/node": "*",
+        "jest-util": "30.0.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-util": {
+      "version": "30.0.2",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.0.2.tgz",
+      "integrity": "sha512-8IyqfKS4MqprBuUpZNlFB5l+WFehc8bfCe1HSZFHzft2mOuND8Cvi9r1musli+u6F3TqanCZ/Ik4H4pXUolZIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.0.1",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@types/jest/node_modules/pretty-format": {
+      "version": "30.0.2",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.0.2.tgz",
+      "integrity": "sha512-yC5/EBSOrTtqhCKfLHqoUIAXVRZnukHPwWBJWR7h84Q3Be1DRQZLncwcfLoPA5RPQ65qfiCMqgYwdUuQ//eVpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.0.1",
+        "ansi-styles": "^5.2.0",
+        "react-is": "^18.3.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -7375,6 +7663,12 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/dexie": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/dexie/-/dexie-4.0.11.tgz",
+      "integrity": "sha512-SOKO002EqlvBYYKQSew3iymBoN2EQ4BDw/3yprjh7kAfFzjBYkaMNa/pZvcA7HSWlcKSQb9XhPe3wKyQ0x4A8A==",
+      "license": "Apache-2.0"
+    },
     "node_modules/didyoumean": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
@@ -8749,6 +9043,15 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.0.1.tgz",
+      "integrity": "sha512-He2AjQGHe46svIFq5+L2Nx/eHDTI1oKgoevBP+TthnjymXiKkeJQ3+ITeWey99Y5+2OaPFbI1qEsx/5RsGtWnQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^13.5.0",
+    "dexie": "^4.0.11",
     "esm": "^3.2.25",
+    "fake-indexeddb": "^6.0.1",
     "jspdf": "^2.5.1",
     "jspdf-autotable": "^3.5.25",
     "lucide-react": "^0.517.0",
@@ -49,6 +51,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",
+    "@types/jest": "^30.0.0",
     "eslint": "^8.57.1",
     "eslint-plugin-react": "^7.37.5",
     "globals": "^16.2.0"

--- a/scripts/check-store.ts
+++ b/scripts/check-store.ts
@@ -1,0 +1,13 @@
+import { parseFundFile } from '../src/utils/parseFundFile'
+import db, { addSnapshot, listSnapshots, setActiveSnapshot, getActiveSnapshot } from '../src/services/snapshotStore'
+import fs from 'fs/promises'
+
+;(async () => {
+  const buf = await fs.readFile('data/historical/June2024_FundPerformance.csv')
+  const file = new File([buf], 'June2024_FundPerformance.csv')
+  const snap = await parseFundFile(file)
+  await addSnapshot(snap, '2024-06', 'back-fill')
+  await setActiveSnapshot('2024-06')
+  console.log('Active:', (await getActiveSnapshot())?.id)
+  console.log('Total snapshots in DB:', (await listSnapshots()).length)
+})()

--- a/src/__tests__/snapshotStore.test.js
+++ b/src/__tests__/snapshotStore.test.js
@@ -1,0 +1,57 @@
+import 'fake-indexeddb/auto'
+// Jest's jsdom environment may not provide structuredClone
+global.structuredClone =
+  global.structuredClone || ((v) => JSON.parse(JSON.stringify(v)))
+import db, {
+  addSnapshot,
+  listSnapshots,
+  getSnapshot,
+  setActiveSnapshot,
+  getActiveSnapshot,
+  softDeleteSnapshot
+} from '../services/snapshotStore'
+
+const baseSnap = {
+  rows: [],
+  source: 'file.csv',
+  checksum: 'abc'
+}
+
+describe('snapshotStore', () => {
+  beforeEach(async () => {
+    await db.delete()
+    await db.open()
+  })
+
+  afterAll(async () => {
+    await db.delete()
+  })
+
+  test('addSnapshot and retrieve', async () => {
+    await addSnapshot(baseSnap, '2024-06')
+    const row = await getSnapshot('2024-06')
+    expect(row.id).toBe('2024-06')
+  })
+
+  test('duplicate checksum rejected', async () => {
+    await addSnapshot(baseSnap, '2024-06')
+    await expect(addSnapshot(baseSnap, '2024-07')).rejects.toThrow('duplicate checksum')
+  })
+
+  test('setActiveSnapshot toggles active flag', async () => {
+    const snapB = { rows: [], source: 'b.csv', checksum: 'b' }
+    await addSnapshot(baseSnap, '2024-06')
+    await addSnapshot(snapB, '2024-07')
+    await setActiveSnapshot('2024-07')
+    const active = await getActiveSnapshot()
+    expect(active.id).toBe('2024-07')
+  })
+
+  test('softDeleteSnapshot flags deletion', async () => {
+    await addSnapshot(baseSnap, '2024-06')
+    await softDeleteSnapshot('2024-06')
+    const row = await getSnapshot('2024-06')
+    expect(row.deleted).toBe(true)
+    expect(row.active).toBe(false)
+  })
+})

--- a/src/services/snapshotStore.ts
+++ b/src/services/snapshotStore.ts
@@ -1,0 +1,64 @@
+import Dexie, { Table } from 'dexie'
+import { ParsedSnapshot } from '../utils/parseFundFile'
+
+export interface SnapshotRow extends ParsedSnapshot {
+  /** YYYY-MM e.g. "2024-06" */
+  id: string
+  uploaded: string
+  note?: string | null
+  active?: boolean
+  deleted?: boolean
+}
+
+class SnapshotDB extends Dexie {
+  snapshots!: Table<SnapshotRow, string>
+  constructor () {
+    super('LightshipSnapshots')
+    this.version(1).stores({
+      snapshots: 'id, uploaded, active'
+    })
+  }
+}
+
+const db = new SnapshotDB()
+export default db
+
+export async function addSnapshot (
+  snap: ParsedSnapshot,
+  id: string,
+  note: string | null = null
+): Promise<void> {
+  const duplicate = await db.snapshots.filter(r => r.checksum === snap.checksum).first()
+  if (duplicate) throw new Error('duplicate checksum')
+  const row: SnapshotRow = {
+    ...snap,
+    id,
+    uploaded: new Date().toISOString(),
+    note,
+    active: false
+  }
+  await db.snapshots.add(row)
+}
+
+export async function listSnapshots (): Promise<SnapshotRow[]> {
+  return await db.snapshots.toArray()
+}
+
+export async function getSnapshot (id: string): Promise<SnapshotRow | undefined> {
+  return await db.snapshots.get(id)
+}
+
+export async function setActiveSnapshot (id: string): Promise<void> {
+  await db.transaction('rw', db.snapshots, async () => {
+    await db.snapshots.toCollection().modify(row => { row.active = false })
+    await db.snapshots.update(id, { active: true })
+  })
+}
+
+export async function getActiveSnapshot (): Promise<SnapshotRow | undefined> {
+  return await db.snapshots.filter(r => r.active === true).first()
+}
+
+export async function softDeleteSnapshot (id: string): Promise<void> {
+  await db.snapshots.update(id, { active: false, deleted: true })
+}


### PR DESCRIPTION
## Summary
- add Dexie + fake-indexeddb and types
- implement `src/services/snapshotStore.ts` for storing parsed snapshots
- include basic CRUD helpers and active/duplicate logic
- add sample script `scripts/check-store.ts`
- test snapshot store behaviours

## Testing
- `npm test --silent -- -u`
- `npx tsc --noEmit`
- `npx tsx -r fake-indexeddb/auto scripts/check-store.ts`
- `npx tsx scripts/run-twice.ts` *(shows duplicate checksum)*

------
https://chatgpt.com/codex/tasks/task_e_685d78c7ea9c83299ad6095e731fa8b5