### PR TITLE
Replace Node crypto sha1

### DIFF
--- a/src/utils/__tests__/hash.test.ts
+++ b/src/utils/__tests__/hash.test.ts
@@ -1,0 +1,15 @@
+import { sha1Hex } from '../hash'
+import { TextEncoder } from 'util'
+
+// polyfill TextEncoder for jsdom environment
+(global as any).TextEncoder = (global as any).TextEncoder || TextEncoder
+
+describe('sha1Hex', () => {
+  it('computes SHA-1 hex for Uint8Array', async () => {
+    const enc = new TextEncoder()
+    const data = enc.encode('hello')
+    const hex = await sha1Hex(data)
+    expect(hex).toBe('aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d')
+  })
+
+})

--- a/src/utils/__tests__/parseFundFile.test.ts
+++ b/src/utils/__tests__/parseFundFile.test.ts
@@ -1,5 +1,9 @@
 import { parseFundFile } from '../parseFundFile'
 import fs from 'fs/promises'
+import { File as NodeFile } from 'node:buffer'
+
+// polyfill File for older Node / jsdom environments
+(global as any).File = (global as any).File || NodeFile
 
 describe('parseFundFile', () => {
   it('parses Raymond James sample', async () => {

--- a/src/utils/hash.ts
+++ b/src/utils/hash.ts
@@ -1,0 +1,12 @@
+/** Compute SHA-1 hex digest for a File or Uint8Array or Blob */
+export async function sha1Hex(data: ArrayBuffer | Uint8Array | Blob): Promise<string> {
+  const buf = data instanceof Blob
+    ? await data.arrayBuffer()
+    : data instanceof Uint8Array
+      ? data.buffer
+      : data
+  const hash = await crypto.subtle.digest('SHA-1', buf)
+  return Array.from(new Uint8Array(hash))
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('')
+}

--- a/src/utils/parseFundFile.ts
+++ b/src/utils/parseFundFile.ts
@@ -1,6 +1,6 @@
 // src/utils/parseFundFile.ts
 import * as XLSX from 'xlsx'
-import { createHash } from 'crypto'
+import { sha1Hex } from './hash'
 import { recommendedFunds } from '../data/config.js'
 
 export const COLUMN_MAP: Record<string, keyof NormalisedRow> = {
@@ -105,10 +105,6 @@ async function readFileAsRows(file: File): Promise<any[][]> {
   return XLSX.utils.sheet_to_json(sheet, { header: 1 }) as any[][]
 }
 
-async function sha1(file: File): Promise<string> {
-  const buf = await file.arrayBuffer()
-  return createHash('sha1').update(Buffer.from(buf)).digest('hex')
-}
 
 export async function parseFundFile(
   file: File,
@@ -193,7 +189,7 @@ export async function parseFundFile(
     id: undefined,
     rows: list,
     source: file.name,
-    checksum: await sha1(file)
+    checksum: await sha1Hex(file)
   }
 }
 


### PR DESCRIPTION
## Summary
- add browser-compatible `sha1Hex` helper
- remove Node `crypto` usage in `parseFundFile`
- adjust tests for new helper and provide polyfills

## Testing
- `npx tsc --noEmit`
- `npm test --silent` *(fails: jsdom environment issues)*
- `npm start` *(started dev server successfully)*

------
https://chatgpt.com/codex/tasks/task_e_685d87093b1c83298a3ba885046d24a2