### PR TITLE
Add trend insights and spark-lines

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "react-hook-form": "^7.49.2",
         "react-hot-toast": "^2.5.2",
         "react-scripts": "5.0.1",
-        "recharts": "^2.15.3",
+        "recharts": "^2.15.4",
         "tsx": "^4.20.3",
         "web-vitals": "^2.1.4",
         "xlsx": "^0.18.5"
@@ -15834,9 +15834,9 @@
       }
     },
     "node_modules/recharts": {
-      "version": "2.15.3",
-      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.3.tgz",
-      "integrity": "sha512-EdOPzTwcFSuqtvkDoaM5ws/Km1+WTAO2eizL7rqiG0V2UVhTnz0m7J2i0CjVPUCdEkZImaWvXLbZDS2H5t6GFQ==",
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.4.tgz",
+      "integrity": "sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "react-hook-form": "^7.49.2",
     "react-hot-toast": "^2.5.2",
     "react-scripts": "5.0.1",
-    "recharts": "^2.15.3",
+    "recharts": "^2.15.4",
     "tsx": "^4.20.3",
     "web-vitals": "^2.1.4",
     "xlsx": "^0.18.5"

--- a/src/__tests__/trendAnalysis.test.ts
+++ b/src/__tests__/trendAnalysis.test.ts
@@ -1,0 +1,54 @@
+import 'fake-indexeddb/auto'
+// polyfill structuredClone for jest env
+(global as any).structuredClone = (global as any).structuredClone || ((v: any) => JSON.parse(JSON.stringify(v)))
+import db, { addSnapshot } from '../services/snapshotStore'
+import { getScoreSeries, delta } from '../services/trendAnalysis'
+import { NormalisedRow } from '../utils/parseFundFile'
+
+describe('trendAnalysis', () => {
+  const baseRow: NormalisedRow = {
+    symbol: 'AAA',
+    productName: null,
+    ytdReturn: null,
+    oneYearReturn: null,
+    threeYearReturn: null,
+    fiveYearReturn: null,
+    tenYearReturn: null,
+    sharpe3y: null,
+    stdDev3y: null,
+    stdDev5y: null,
+    alpha5y: null,
+    netExpenseRatio: null,
+    managerTenure: null
+  }
+
+  beforeEach(async () => {
+    await db.delete()
+    await db.open()
+    for (let i = 1; i <= 7; i++) {
+      const row = { ...baseRow, score: i * 10 }
+      await addSnapshot({ rows: [row], source: 'f.csv', checksum: String(i) }, `2024-0${i}`)
+    }
+  })
+
+  afterAll(async () => {
+    await db.delete()
+  })
+
+  test('getScoreSeries limits and orders data', async () => {
+    const series = await getScoreSeries('AAA', 6)
+    expect(series).toHaveLength(6)
+    expect(series[0].id).toBe('2024-02')
+    expect(series[5].id).toBe('2024-07')
+  })
+
+  test('delta computes latest minus previous', async () => {
+    const series = await getScoreSeries('AAA', 6)
+    const d = delta(series)
+    expect(d).toBe(10)
+  })
+
+  test('delta returns null for short series', () => {
+    expect(delta([{ score: 1 }])).toBeNull()
+  })
+})

--- a/src/components/FundTable.jsx
+++ b/src/components/FundTable.jsx
@@ -3,6 +3,7 @@ import TagList from './TagList.jsx';
 import BenchmarkRow from './BenchmarkRow.jsx';
 import { getScoreColor, getScoreLabel } from '../utils/scoreTags';
 import { fmtPct, fmtNumber } from '../utils/formatters';
+import SparkLine from './SparkLine';
 
 const ScoreBadge = ({ score }) => {
   const color = getScoreColor(score);
@@ -32,6 +33,8 @@ const columns = [
   { key: 'Fund Name', label: 'Fund Name', numeric: false },
   { key: 'Type', label: 'Type', numeric: false, accessor: f => (f.isBenchmark ? 'Benchmark' : f.isRecommended ? 'Recommended' : '') },
   { key: 'Score', label: 'Score', numeric: true, accessor: f => f.scores?.final },
+  { key: 'Delta', label: 'Δ vs last', numeric: true },
+  { key: 'Trend', label: 'Trend', numeric: false },
   { key: 'YTD', label: 'YTD', numeric: true, accessor: f => f.ytd ?? f.YTD },
   { key: '1Y', label: '1Y', numeric: true, accessor: f => f.oneYear ?? f['1 Year'] },
   { key: '3Y', label: '3Y', numeric: true, accessor: f => f.threeYear ?? f['3 Year'] },
@@ -42,7 +45,14 @@ const columns = [
   { key: 'Tags', label: 'Tags', numeric: false, accessor: f => f.tags }
 ];
 
-const FundTable = ({ funds = [], rows, benchmark, onRowClick = () => {} }) => {
+const FundTable = ({
+  funds = [],
+  rows,
+  benchmark,
+  deltas = {},
+  spark = {},
+  onRowClick = () => {}
+}) => {
   const data = rows || funds;
   const [sort, setSort] = useState({ key: null, dir: 'asc', numeric: false });
 
@@ -123,6 +133,26 @@ const FundTable = ({ funds = [], rows, benchmark, onRowClick = () => {} }) => {
             <td style={{ padding: '0.5rem', textAlign: 'center' }}>
               {fund.scores ? <ScoreBadge score={fund.scores.final} /> : '-'}
             </td>
+            {(() => {
+              const sym = fund.Symbol || fund.symbol
+              const d = deltas[sym]
+              return (
+                <>
+                  <td style={{ padding: '0.5rem', minWidth: '70px', textAlign: 'right' }}>
+                    {d == null ? '' : d > 0 ? (
+                      <><span style={{color:'green'}}>▲</span>{d}</>
+                    ) : d < 0 ? (
+                      <><span style={{color:'red'}}>▼</span>{Math.abs(d)}</>
+                    ) : (
+                      '—'
+                    )}
+                  </td>
+                  <td style={{ padding: '0.5rem' }}>
+                    <SparkLine data={spark[sym] ?? []} />
+                  </td>
+                </>
+              )
+            })()}
             <td style={{ padding: '0.5rem', textAlign: 'right' }}>
               {fmtPct(fund.ytd ?? fund.YTD)}
             </td>

--- a/src/components/GroupedFundTable.jsx
+++ b/src/components/GroupedFundTable.jsx
@@ -7,7 +7,7 @@ import FundTable from './FundTable.jsx';
  * @param {Array<Object>} funds
  * @param {Function} onRowClick
  */
-const GroupedFundTable = ({ funds = [], onRowClick = () => {} }) => {
+const GroupedFundTable = ({ funds = [], onRowClick = () => {}, deltas = {}, spark = {} }) => {
   const groups = {};
   funds.forEach(f => {
     const cls = f.assetClass || 'Uncategorized';
@@ -51,7 +51,7 @@ const GroupedFundTable = ({ funds = [], onRowClick = () => {} }) => {
             </div>
             {open[cls] && (
               <div style={{ marginTop: '0.5rem' }}>
-                <FundTable rows={peers} benchmark={benchmark} onRowClick={onRowClick} />
+                <FundTable rows={peers} benchmark={benchmark} onRowClick={onRowClick} deltas={deltas} spark={spark} />
               </div>
             )}
           </div>

--- a/src/components/SparkLine.tsx
+++ b/src/components/SparkLine.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import { LineChart, Line } from 'recharts'
+
+export default function SparkLine ({ data }: { data: number[] }) {
+  if (data.length === 0) return null
+  const chartData = data.map((v, i) => ({ i, v }))
+  return (
+    <LineChart width={80} height={24} data={chartData}>
+      <Line type="monotone" dataKey="v" strokeWidth={2} dot={false} />
+    </LineChart>
+  )
+}

--- a/src/components/__tests__/BenchmarkVisibility.integration.test.jsx
+++ b/src/components/__tests__/BenchmarkVisibility.integration.test.jsx
@@ -4,6 +4,8 @@ import * as XLSX from 'xlsx';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import ClassView from '../ClassView.jsx';
+import { useSnapshot } from '../../contexts/SnapshotContext';
+jest.mock('../../contexts/SnapshotContext', () => ({ useSnapshot: jest.fn() }))
 import parseFundFile from '../../services/parseFundFile';
 import { recommendedFunds, assetClassBenchmarks } from '../../data/config';
 import { calculateScores } from '../../services/scoring';
@@ -37,10 +39,12 @@ async function loadFunds() {
 test('benchmarks visible in class views', async () => {
   const scored = await loadFunds();
   const largeCap = scored.filter(f => f.assetClass === 'Large Cap Growth');
-  render(<ClassView funds={largeCap} />);
+  useSnapshot.mockReturnValueOnce({ active: { rows: largeCap } })
+  render(<ClassView defaultAssetClass="Large Cap Growth" />);
   expect(screen.getByText(/Benchmark — IWF/i)).toBeVisible();
 
   const muni = scored.filter(f => f.assetClass === 'Intermediate Muni');
-  render(<ClassView funds={muni} />);
+  useSnapshot.mockReturnValueOnce({ active: { rows: muni } })
+  render(<ClassView defaultAssetClass="Intermediate Muni" />);
   expect(screen.getByText(/Benchmark — ITM/i)).toBeVisible();
 });

--- a/src/components/__tests__/ClassView.alignment.test.jsx
+++ b/src/components/__tests__/ClassView.alignment.test.jsx
@@ -1,12 +1,15 @@
 import { render } from '@testing-library/react';
 import ClassView from '../ClassView.jsx';
+import { useSnapshot } from '../../contexts/SnapshotContext';
+jest.mock('../../contexts/SnapshotContext', () => ({ useSnapshot: jest.fn() }))
 
 const funds = [
-  { Symbol: 'IWF', 'Fund Name': 'Index', isBenchmark: true, scores: { final: 60 } },
-  { Symbol: 'AAA', 'Fund Name': 'Fund A', scores: { final: 70 } }
+  { Symbol: 'IWF', 'Fund Name': 'Index', assetClass: 'Large Cap Growth', isBenchmark: true, scores: { final: 60 } },
+  { Symbol: 'AAA', 'Fund Name': 'Fund A', assetClass: 'Large Cap Growth', scores: { final: 70 } }
 ];
 
 test('benchmark row aligns with table', () => {
-  const { asFragment } = render(<ClassView funds={funds} />);
+  useSnapshot.mockReturnValue({ active: { rows: funds } })
+  const { asFragment } = render(<ClassView defaultAssetClass="Large Cap Growth" />);
   expect(asFragment()).toMatchSnapshot();
 });

--- a/src/components/__tests__/ClassViewBenchmarkRow.test.jsx
+++ b/src/components/__tests__/ClassViewBenchmarkRow.test.jsx
@@ -1,11 +1,16 @@
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import ClassView from '../ClassView.jsx';
+import { useSnapshot } from '../../contexts/SnapshotContext';
+jest.mock('../../contexts/SnapshotContext', () => ({
+  useSnapshot: jest.fn(),
+}))
 
 const mockLargeCapGrowth = [
   {
     Symbol: 'IWF',
     'Fund Name': 'Russell 1000 Growth',
+    assetClass: 'Large Cap Growth',
     isBenchmark: true,
     ytd: 1,
     oneYear: 2,
@@ -19,6 +24,7 @@ const mockLargeCapGrowth = [
   {
     Symbol: 'AAA',
     'Fund Name': 'Fund A',
+    assetClass: 'Large Cap Growth',
     ytd: 0.5,
     oneYear: 1,
     threeYear: 1.5,
@@ -31,7 +37,8 @@ const mockLargeCapGrowth = [
 ];
 
 test('benchmark row visible in class view', () => {
-  render(<ClassView funds={mockLargeCapGrowth} />);
+  useSnapshot.mockReturnValue({ active: { rows: mockLargeCapGrowth } })
+  render(<ClassView defaultAssetClass="Large Cap Growth" />);
   expect(screen.getByText(/Benchmark — IWF/i)).toBeInTheDocument();
 });
 

--- a/src/components/__tests__/FundTable.test.jsx
+++ b/src/components/__tests__/FundTable.test.jsx
@@ -17,6 +17,8 @@ const sample = [{
 }];
 
 test('renders table snapshot', () => {
-  const { asFragment } = render(<FundTable funds={sample} onRowClick={() => {}} />);
+  const { asFragment } = render(
+    <FundTable funds={sample} onRowClick={() => {}} deltas={{}} spark={{}} />
+  );
   expect(asFragment()).toMatchSnapshot();
 });

--- a/src/components/__tests__/TagFilterBar.integration.test.jsx
+++ b/src/components/__tests__/TagFilterBar.integration.test.jsx
@@ -1,7 +1,17 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import FundScores from '../../routes/FundScores';
 import AppContext from '../../context/AppContext.jsx';
+import { useSnapshot } from '../../contexts/SnapshotContext';
+jest.mock('../../contexts/SnapshotContext', () => ({ useSnapshot: jest.fn() }))
+jest.mock('../../services/trendAnalysis', () => ({
+  getScoreSeries: jest.fn().mockResolvedValue([]),
+  delta: jest.fn().mockReturnValue(null)
+}))
+jest.mock('../../services/exportService', () => ({
+  exportToExcel: jest.fn(),
+  exportToPDF: jest.fn(),
+}))
 import React, { useState } from 'react';
 
 function Wrapper({ children }) {
@@ -29,11 +39,17 @@ function Wrapper({ children }) {
 }
 
 test('filter pill toggles rows', async () => {
-  render(
-    <Wrapper>
-      <FundScores />
-    </Wrapper>
-  );
+  useSnapshot.mockReturnValue({ active: { rows: [
+    { symbol: 'A', assetClass: 'X', scores: { final: 50 }, tags: ['Review'] },
+    { symbol: 'B', assetClass: 'X', scores: { final: 60 }, tags: [] }
+  ] } })
+  await act(async () => {
+    render(
+      <Wrapper>
+        <FundScores />
+      </Wrapper>
+    );
+  });
   const table = screen.getByRole('table');
   expect(table.querySelectorAll('tbody tr').length).toBe(2);
   await userEvent.click(screen.getByRole('button', { name: 'Review' }));

--- a/src/components/__tests__/__snapshots__/ClassView.alignment.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/ClassView.alignment.test.jsx.snap
@@ -24,6 +24,8 @@ exports[`benchmark row aligns with table 1`] = `
           <col />
           <col />
           <col />
+          <col />
+          <col />
         </colgroup>
         <thead>
           <tr
@@ -48,6 +50,16 @@ exports[`benchmark row aligns with table 1`] = `
               style="padding: 0.75rem; text-align: right; font-weight: 500; cursor: pointer;"
             >
               Score
+            </th>
+            <th
+              style="padding: 0.75rem; text-align: right; font-weight: 500; cursor: pointer;"
+            >
+              Δ vs last
+            </th>
+            <th
+              style="padding: 0.75rem; text-align: left; font-weight: 500; cursor: pointer;"
+            >
+              Trend
             </th>
             <th
               style="padding: 0.75rem; text-align: right; font-weight: 500; cursor: pointer;"
@@ -185,6 +197,12 @@ exports[`benchmark row aligns with table 1`] = `
                 70.0 - Strong
               </span>
             </td>
+            <td
+              style="padding: 0.5rem; min-width: 70px; text-align: right;"
+            />
+            <td
+              style="padding: 0.5rem;"
+            />
             <td
               style="padding: 0.5rem; text-align: right;"
             >

--- a/src/components/__tests__/__snapshots__/FundTable.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/FundTable.test.jsx.snap
@@ -21,6 +21,8 @@ exports[`renders table snapshot 1`] = `
         <col />
         <col />
         <col />
+        <col />
+        <col />
       </colgroup>
       <thead>
         <tr
@@ -45,6 +47,16 @@ exports[`renders table snapshot 1`] = `
             style="padding: 0.75rem; text-align: right; font-weight: 500; cursor: pointer;"
           >
             Score
+          </th>
+          <th
+            style="padding: 0.75rem; text-align: right; font-weight: 500; cursor: pointer;"
+          >
+            Δ vs last
+          </th>
+          <th
+            style="padding: 0.75rem; text-align: left; font-weight: 500; cursor: pointer;"
+          >
+            Trend
           </th>
           <th
             style="padding: 0.75rem; text-align: right; font-weight: 500; cursor: pointer;"
@@ -116,6 +128,12 @@ exports[`renders table snapshot 1`] = `
               75.0 - Strong
             </span>
           </td>
+          <td
+            style="padding: 0.5rem; min-width: 70px; text-align: right;"
+          />
+          <td
+            style="padding: 0.5rem;"
+          />
           <td
             style="padding: 0.5rem; text-align: right;"
           >

--- a/src/routes/FundScores.tsx
+++ b/src/routes/FundScores.tsx
@@ -11,6 +11,10 @@ import { addSnapshot, setActiveSnapshot } from '../services/snapshotStore'
 import UploadIcon from '@mui/icons-material/Upload'
 import { Download } from 'lucide-react'
 import { exportToExcel } from '../services/exportService'
+import SparkLine from '../components/SparkLine'
+import { getScoreSeries, delta } from '../services/trendAnalysis'
+import ArrowDropUpIcon from '@mui/icons-material/ArrowDropUp'
+import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown'
 import {
   Box, Button, Dialog, DialogTitle, DialogContent, DialogActions,
   TextField, MenuItem
@@ -42,6 +46,18 @@ export default function FundScores () {
   const [year, setYear] = useState('')
   const [month, setMonth] = useState('')
 
+  const [deltas, setDeltas] = useState<Record<string, number>>({})
+  const [spark, setSpark] = useState<Record<string, number[]>>({})
+  const [seriesCache] = React.useState<Record<string, number[]>>({})
+
+  const getSeries = async (symbol: string) => {
+    if (!seriesCache[symbol]) {
+      const series = await getScoreSeries(symbol, 6)
+      seriesCache[symbol] = (series ?? []).map(s => s.score)
+    }
+    return seriesCache[symbol]
+  }
+
   const handleQuickUpload = async () => {
     if (!file || !year || !month) return
     const snap = await parseFundFile(file)
@@ -69,6 +85,22 @@ export default function FundScores () {
     if (filteredFunds.length === 0) return
     exportToExcel(filteredFunds)
   }
+
+  React.useEffect(() => {
+    (async () => {
+      const nextD: Record<string, number> = {}
+      const nextS: Record<string, number[]> = {}
+
+      await Promise.all(rows.map(async r => {
+        const series = await getSeries(r.symbol)
+        nextS[r.symbol] = series
+        const d = delta(series.map(s => ({ score: s })))
+        if (d != null) nextD[r.symbol] = d
+      }))
+
+      setDeltas(nextD); setSpark(nextS)
+    })()
+  }, [rows])
 
   if (!active) {
     return (
@@ -118,9 +150,9 @@ export default function FundScores () {
       {filteredFunds.length === 0 ? (
         <p style={{ color: '#6b7280' }}>No funds match your current filter selection.</p>
       ) : grouped ? (
-        <GroupedTable funds={filteredFunds as any} onRowClick={setSelectedFund} />
+        <GroupedTable funds={filteredFunds as any} onRowClick={setSelectedFund} deltas={deltas} spark={spark} />
       ) : (
-        <FundTableAny funds={filteredFunds as any} onRowClick={setSelectedFund as any} />
+        <FundTableAny funds={filteredFunds as any} onRowClick={setSelectedFund as any} deltas={deltas} spark={spark} />
       )}
       {selectedFund && (
         <FundDetailsModal fund={selectedFund} onClose={() => setSelectedFund(null)} />

--- a/src/services/trendAnalysis.ts
+++ b/src/services/trendAnalysis.ts
@@ -1,0 +1,24 @@
+import db from './snapshotStore'
+import { NormalisedRow } from '../utils/parseFundFile'
+
+/** Return score series (sorted oldest\u279enewest) for given symbol, max N points */
+export async function getScoreSeries (symbol: string, limit = 6):
+  Promise<{ id: string; score: number }[]> {
+
+  const snaps = await db.snapshots.orderBy('id').reverse().limit(limit).toArray()
+  return snaps
+    .map(s => {
+      const row = (s.rows as any as NormalisedRow[]).find(r => r.symbol === symbol)
+      return row ? { id: s.id, score: (row as any).score ?? 0 } : null
+    })
+    .filter(Boolean)
+    .reverse() as { id: string; score: number }[]
+}
+
+/** MoM delta (current \u2013 previous) */
+export function delta (series: { score: number }[]): number | null {
+  if (series.length < 2) return null
+  const latest = series[series.length - 1]?.score
+  const prev   = series[series.length - 2]?.score
+  return latest != null && prev != null ? +(latest - prev).toFixed(1) : null
+}


### PR DESCRIPTION
## Summary
- introduce recharts
- add `trendAnalysis` service for score history
- display score deltas and spark-lines in fund tables
- provide `SparkLine` component
- update tests and snapshots

## Testing
- `npx tsc --noEmit`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685d8d6d553083298f0d1c4b1f13e6e1