### PR TITLE
Add heatmap analysis route

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
         "@mui/icons-material": "^7.1.2",
+        "@mui/lab": "^7.0.0-beta.14",
         "@mui/material": "^7.1.2",
         "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.6.3",
@@ -3658,6 +3659,50 @@
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/lab": {
+      "version": "7.0.0-beta.14",
+      "resolved": "https://registry.npmjs.org/@mui/lab/-/lab-7.0.0-beta.14.tgz",
+      "integrity": "sha512-pn+ZvylDcBKQOo17oa/PhtIA/UFQFq8RvpN+r/jHrztz/CjMDju2CWBne0txvQ5JIS8uTIGp2/IsTa7II1g5wg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.1",
+        "@mui/system": "^7.1.1",
+        "@mui/types": "^7.4.3",
+        "@mui/utils": "^7.1.1",
+        "clsx": "^2.1.1",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.5.0",
+        "@emotion/styled": "^11.3.0",
+        "@mui/material": "^7.1.2",
+        "@mui/material-pigment-css": "^7.1.1",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "@mui/material-pigment-css": {
+          "optional": true
+        },
         "@types/react": {
           "optional": true
         }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
     "@mui/icons-material": "^7.1.2",
+    "@mui/lab": "^7.0.0-beta.14",
     "@mui/material": "^7.1.2",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -21,7 +21,7 @@ import ClassView from './routes/ClassView';
 import AdminPanel from './components/AdminPanel.jsx';
 import AppContext from './context/AppContext.jsx';
 import TagFilterBar from './components/Filters/TagFilterBar.jsx';
-import AnalysisView from './components/Views/AnalysisView.jsx';
+import AnalysisView from './routes/AnalysisView';
 import HistoricalManager from './routes/HistoricalManager';
 // Score badge component for visual display
 const ScoreBadge = ({ score, size = 'normal' }) => {

--- a/src/__tests__/AnalysisHeatmap.test.tsx
+++ b/src/__tests__/AnalysisHeatmap.test.tsx
@@ -1,0 +1,11 @@
+import { bucket } from '../routes/AnalysisView'
+
+describe('bucket', () => {
+  test('categorises scores', () => {
+    expect(bucket(null)).toBe('blank')
+    expect(bucket(85)).toBe('top')
+    expect(bucket(65)).toBe('good')
+    expect(bucket(45)).toBe('weak')
+    expect(bucket(20)).toBe('poor')
+  })
+})

--- a/src/routes/AnalysisView.tsx
+++ b/src/routes/AnalysisView.tsx
@@ -1,0 +1,74 @@
+import React from 'react'
+import { Box, Tooltip, Typography } from '@mui/material'
+import { useSnapshot } from '../contexts/SnapshotContext'
+import db from '../services/snapshotStore'
+
+export function bucket (score: number | null) {
+  if (score == null) return 'blank'
+  if (score >= 80) return 'top'
+  if (score >= 60) return 'good'
+  if (score >= 40) return 'weak'
+  return 'poor'
+}
+
+const colours: Record<string,string> = {
+  top:  '#006400',
+  good: '#66bb6a',
+  weak: '#ef9a9a',
+  poor: '#c62828',
+  blank:'#e0e0e0'
+}
+
+export default function AnalysisView () {
+  const { list, active } = useSnapshot()
+  const last12 = React.useMemo(
+    () => [...list].sort((a,b)=>a.id.localeCompare(b.id)).slice(-12),
+    [list]
+  )
+  if (!active) return <Typography p={3}>No snapshot selected.</Typography>
+
+  // build matrix
+  const rows = active.rows.map(r => {
+    const cells = last12.map(snap => {
+      const match = snap.rows.find(x => x.symbol === r.symbol)
+      return { id: snap.id, score: (match as any)?.score ?? null }
+    })
+    return { symbol: r.symbol, cells }
+  })
+
+  return (
+    <Box p={3} sx={{ overflowX:'auto' }}>
+      <Typography variant="h5" mb={2}>Heat-map (Score by Month)</Typography>
+
+      <Box sx={{ display:'grid',
+                 gridTemplateColumns:`120px repeat(${last12.length},36px)` }}>
+        {/* header row */}
+        <Box />
+        {last12.map(s => (
+          <Box key={s.id}
+               sx={{ textAlign:'center', fontSize:12, px:0.5 }}>{s.id}</Box>
+        ))}
+
+        {/* data rows */}
+        {rows.map(r => (
+          <React.Fragment key={r.symbol}>
+            <Box sx={{ fontSize:12, pr:1 }}>{r.symbol}</Box>
+            {r.cells.map(c => (
+              <Tooltip
+                key={c.id}
+                title={`${r.symbol} • ${c.id} • ${c.score ?? '—'}`}
+                arrow
+              >
+                <Box sx={{
+                  width:34, height:18, m:0.25,
+                  bgcolor: colours[bucket(c.score)],
+                  borderRadius: '3px'
+                }} />
+              </Tooltip>
+            ))}
+          </React.Fragment>
+        ))}
+      </Box>
+    </Box>
+  )
+}


### PR DESCRIPTION
## Summary
- install `@mui/lab`
- wire new `AnalysisView` route
- compute heatmap buckets and colors
- provide Jest tests for bucket utility

## Testing
- `npx tsc --noEmit`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685d952cec148329a488832e88938b46