### PR TITLE
Implement trending tag rules

### DIFF
--- a/src/components/TagList.jsx
+++ b/src/components/TagList.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Chip from '@mui/material/Chip';
 
 const TAG_COLORS = {
   Review: '#dc2626',
@@ -22,19 +23,13 @@ const TagList = ({ tags }) => {
       {tags.map(tag => {
         const color = TAG_COLORS[tag] || '#6b7280';
         return (
-          <span
+          <Chip
             key={tag}
-            style={{
-              backgroundColor: `${color}20`,
-              color,
-              border: `1px solid ${color}40`,
-              borderRadius: '9999px',
-              fontSize: '0.7rem',
-              padding: '0.125rem 0.5rem'
-            }}
-          >
-            {tag}
-          </span>
+            label={tag}
+            size="small"
+            style={{ backgroundColor: `${color}20`, color, borderColor: `${color}40` }}
+            variant="outlined"
+          />
         );
       })}
     </div>

--- a/src/routes/FundScores.tsx
+++ b/src/routes/FundScores.tsx
@@ -7,7 +7,8 @@ import FundDetailsModal from '../components/Modals/FundDetailsModal.jsx'
 import AppContext from '../context/AppContext.jsx'
 import { useSnapshot } from '../contexts/SnapshotContext'
 import { NormalisedRow, parseFundFile } from '../utils/parseFundFile'
-import { addSnapshot, setActiveSnapshot } from '../services/snapshotStore'
+import db, { addSnapshot, setActiveSnapshot } from '../services/snapshotStore'
+import { applyTagRules } from '../services/tagRules'
 import UploadIcon from '@mui/icons-material/Upload'
 import { Download } from 'lucide-react'
 import { exportToExcel } from '../services/exportService'
@@ -62,7 +63,9 @@ export default function FundScores () {
     if (!file || !year || !month) return
     const snap = await parseFundFile(file)
     const id = `${year}-${month}`
-    await addSnapshot(snap, id, 'quick upload')
+    const recent = await db.snapshots.orderBy('id').reverse().limit(2).toArray()
+    const tagged = applyTagRules([...recent.reverse(), snap])
+    await addSnapshot(tagged, id, 'quick upload')
     await setActiveSnapshot(id)
     setOpen(false); setFile(null); setYear(''); setMonth('')
   }

--- a/src/routes/HistoricalManager.tsx
+++ b/src/routes/HistoricalManager.tsx
@@ -7,7 +7,8 @@ import DeleteIcon from '@mui/icons-material/Delete'
 import CheckIcon from '@mui/icons-material/Check'
 import UploadIcon from '@mui/icons-material/Upload'
 import { parseFundFile } from '../utils/parseFundFile'
-import { addSnapshot, softDeleteSnapshot } from '../services/snapshotStore'
+import db, { addSnapshot, softDeleteSnapshot } from '../services/snapshotStore'
+import { applyTagRules } from '../services/tagRules'
 import { useSnapshot } from '../contexts/SnapshotContext'
 
 export default function HistoricalManager () {
@@ -26,7 +27,9 @@ export default function HistoricalManager () {
     if (!file || !year || !month) return
     const snap = await parseFundFile(file)
     const id = `${year}-${month}`
-    await addSnapshot(snap, id, 'manual upload')
+    const recent = await db.snapshots.orderBy('id').reverse().limit(2).toArray()
+    const tagged = applyTagRules([...recent.reverse(), snap])
+    await addSnapshot(tagged, id, 'manual upload')
     await setActive(id)
     setOpen(false); setFile(null); setYear(''); setMonth('')
   }

--- a/src/services/__tests__/tagRules.test.ts
+++ b/src/services/__tests__/tagRules.test.ts
@@ -1,0 +1,36 @@
+import { applyTagRules } from '../tagRules'
+import { ParsedSnapshot } from '../../utils/parseFundFile'
+
+describe('applyTagRules', () => {
+  function makeSnap(id: string, score: number): ParsedSnapshot {
+    return {
+      id,
+      rows: [{ symbol: 'AAA', score } as any],
+      source: 'x',
+      checksum: id
+    }
+  }
+
+  test('improving tag', () => {
+    const s1 = makeSnap('1', 50)
+    const s2 = makeSnap('2', 55)
+    const s3 = makeSnap('3', 61)
+    const latest = applyTagRules([s1, s2, s3])
+    expect(latest.rows[0].tags).toContain('improving')
+  })
+
+  test('deteriorating tag', () => {
+    const s1 = makeSnap('1', 60)
+    const s2 = makeSnap('2', 55)
+    const s3 = makeSnap('3', 49)
+    const latest = applyTagRules([s1, s2, s3])
+    expect(latest.rows[0].tags).toContain('deteriorating')
+  })
+
+  test('volatile tag', () => {
+    const scores = [50,70,30,70,30,70]
+    const snaps = scores.map((sc,i) => makeSnap(String(i), sc))
+    const latest = applyTagRules(snaps)
+    expect(latest.rows[0].tags).toContain('volatile')
+  })
+})

--- a/src/services/tagRules.ts
+++ b/src/services/tagRules.ts
@@ -1,0 +1,39 @@
+import { ParsedSnapshot } from '../utils/parseFundFile'
+
+export function applyTagRules (snapshots: ParsedSnapshot[]): ParsedSnapshot {
+  const latest = snapshots[snapshots.length - 1]
+  const prev   = snapshots[snapshots.length - 2]
+  const prev2  = snapshots[snapshots.length - 3]
+
+  latest.rows.forEach(row => {
+    const history = snapshots
+      .slice(-6)
+      .map(s => s.rows.find(r => r.symbol === row.symbol))
+      .filter(Boolean) as any[]
+
+    const scores = history.map(h => h.score ?? null).filter(n => n != null) as number[]
+    const tags: string[] = []
+
+    // Improving / deteriorating
+    if (prev && prev2) {
+      const curr   = row as any
+      const score1 = (prev.rows.find(r => r.symbol === row.symbol) as any)?.score
+      const score2 = (prev2.rows.find(r => r.symbol === row.symbol) as any)?.score
+      if (score1 != null && score2 != null) {
+        if (curr.score - score1 >= 5 && score1 - score2 > 0) tags.push('improving')
+        if (curr.score - score1 <= -5 && score1 - score2 < 0) tags.push('deteriorating')
+      }
+    }
+
+    // Volatile
+    if (scores.length >= 6) {
+      const avg = scores.reduce((a,b)=>a+b,0)/scores.length
+      const sd  = Math.sqrt(scores.map(x => (x-avg)**2).reduce((a,b)=>a+b,0)/scores.length)
+      if (sd >= 15) tags.push('volatile')
+    }
+
+    ;(row as any).tags = tags
+  })
+
+  return latest
+}

--- a/src/utils/parseFundFile.ts
+++ b/src/utils/parseFundFile.ts
@@ -63,6 +63,7 @@ export interface NormalisedRow {
   upCapture3y?: number | null
   downCapture3y?: number | null
   rankYtd?: number | null
+  tags?: string[]
 }
 
 export interface ParsedSnapshot {


### PR DESCRIPTION
## Summary
- add automatic tag inference service
- show tags with MUI Chips
- tag new snapshots during upload flows
- extend `NormalisedRow` with `tags` field
- test tag rule logic

## Testing
- `npx tsc --noEmit`
- `CI=1 NODE_OPTIONS=--experimental-global-webcrypto npm test -- src/services/__tests__/tagRules.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_685d9a7b26e483298a0c395d59a72a20