### PR TITLE
Fix build-blockers in scoring and snapshot handling

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -145,8 +145,6 @@ const App = () => {
     setFundData(snapshot.funds);
     setScoredFundData(snapshot.funds);
     setClassSummaries(snapshot.classSummaries || {});
-    setCurrentSnapshotDate(new Date(snapshot.date).toLocaleDateString());
-    setUploadedFileName(snapshot.metadata?.fileName || 'Historical snapshot');
     
     // Extract benchmark data
     const benchmarks = {};

--- a/src/components/GroupedFundTable.jsx
+++ b/src/components/GroupedFundTable.jsx
@@ -24,12 +24,12 @@ const GroupedFundTable = ({ funds = [], onRowClick = () => {}, deltas = {}, spar
       {Object.entries(groups).map(([cls, rows]) => {
         const benchmark = rows.find(r => r.isBenchmark);
         const peers = rows.filter(r => !r.isBenchmark);
-        const avg = peers.length
-          ? Math.round(
-              peers.reduce((s, f) => s + (f.score ?? f.scores?.final || 0), 0) / peers.length
-            )
-          : 0;
-        const benchScore = benchmark?.score ?? benchmark?.scores?.final;
+          const avg = peers.length
+            ? Math.round(
+                peers.reduce((s, f) => s + ((f.score ?? f.scores?.final) || 0), 0) / peers.length
+              )
+            : 0;
+        const benchScore = (benchmark?.score ?? benchmark?.scores?.final) || 0;
         return (
           <div key={cls} style={{ marginBottom: '1rem' }}>
             <div


### PR DESCRIPTION
## Summary
- fix nullish-coalescing for fund and benchmark scores
- remove unused snapshot state setters

## Testing
- `npm test --silent`
- `npm start` *(compiles successfully)*

------
https://chatgpt.com/codex/tasks/task_e_685daf441a0483299e971787f6f9b022