### PR TITLE
Activate snapshot after upload

### DIFF
--- a/src/routes/FundScores.tsx
+++ b/src/routes/FundScores.tsx
@@ -19,7 +19,7 @@ import ArrowDropUpIcon from '@mui/icons-material/ArrowDropUp'
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown'
 import {
   Box, Button, Dialog, DialogTitle, DialogContent, DialogActions,
-  TextField, MenuItem
+  TextField, MenuItem, Typography
 } from '@mui/material'
 
 const GroupedTable: React.FC<any> = GroupedFundTable as unknown as React.FC<any>
@@ -109,8 +109,15 @@ export default function FundScores () {
 
   if (!active) {
     return (
-      <Box p={3} textAlign='center'>
-        <Button variant='contained' startIcon={<UploadIcon />} onClick={() => setUploadOpen(true)}>Quick Upload</Button>
+      <Box p={3} textAlign="center">
+        <Typography mb={2}>
+          No snapshot saved yet – upload one to get started.
+        </Typography>
+
+        <Button variant="contained" onClick={() => setUploadOpen(true)}>
+          QUICK UPLOAD
+        </Button>
+
         <Dialog open={uploadOpen} onClose={() => setUploadOpen(false)}>
           <DialogTitle>Quick Upload</DialogTitle>
           <DialogContent sx={{ display:'flex', flexDirection:'column', gap:2, mt:1 }}>
@@ -130,7 +137,6 @@ export default function FundScores () {
             <Button onClick={handleQuickUpload} variant='contained' disabled={!file || !year || !month}>Save</Button>
           </DialogActions>
         </Dialog>
-        <Box mt={4}>No snapshot selected – upload one or pick from Historical Data.</Box>
       </Box>
     )
   }

--- a/src/routes/HistoricalManager.tsx
+++ b/src/routes/HistoricalManager.tsx
@@ -9,7 +9,7 @@ import UploadIcon from '@mui/icons-material/Upload'
 import DownloadIcon from '@mui/icons-material/Download'
 import { parseFundFile } from '../utils/parseFundFile'
 import { attachScores } from '../services/scoringUtils'
-import db, { addSnapshot, softDeleteSnapshot } from '../services/snapshotStore'
+import db, { addSnapshot, softDeleteSnapshot, setActiveSnapshot } from '../services/snapshotStore'
 import { applyTagRules } from '../services/tagRules'
 import { useSnapshot } from '../contexts/SnapshotContext'
 import { buildSnapshotPdf } from '../services/pdfExport'
@@ -34,6 +34,7 @@ export default function HistoricalManager () {
     const recent = await db.snapshots.orderBy('id').reverse().limit(2).toArray()
     snap = applyTagRules([...recent.reverse(), snap])
     await addSnapshot(snap, id, 'manual upload')
+    await setActiveSnapshot(id)
     await setActive(id)
     setOpen(false); setFile(null); setYear(''); setMonth('')
   }


### PR DESCRIPTION
## Summary
- activate snapshot after uploading new data in HistoricalManager
- show quick upload message when no snapshot exists
- ensure quick-upload flow marks new snapshot active

## Testing
- `npm test --silent`
- `npm start` *(fails to run due to interactive mode but webpack compiled with warnings)*

------
https://chatgpt.com/codex/tasks/task_e_685df81ea230832989cbb7166c9dcd77