### PR TITLE
Fix ESLint config import error

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ You may also see any lint errors in the console.
 Launches the test runner in the interactive watch mode.\
 See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
 
+### `npx eslint .`
+
+Runs the ESLint linter using the flat configuration in `eslint.config.mjs`.
+
 ### `npm run build`
 
 Builds the app for production to the `build` folder.\

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,11 +1,10 @@
 import js from "@eslint/js";
 import globals from "globals";
 import pluginReact from "eslint-plugin-react";
-import { defineConfig } from "eslint/config";
 
 
-export default defineConfig([
-  { files: ["**/*.{js,mjs,cjs,jsx}"], plugins: { js }, extends: ["js/recommended"] },
+export default [
+  js.configs.recommended,
   { files: ["**/*.{js,mjs,cjs,jsx}"], languageOptions: { globals: globals.browser } },
   pluginReact.configs.flat.recommended,
-]);
+];


### PR DESCRIPTION
## Summary
- update `eslint.config.mjs` to avoid `eslint/config` import
- document `npx eslint .` command in README

## Testing
- `npx eslint .`
- `CI=true npm test --silent` *(fails: sha1Hex computes SHA-1 hex for Uint8Array, parseFundFile parses Raymond James sample, parseFundFile parses YCharts sample, renders table snapshot)*

------
https://chatgpt.com/codex/tasks/task_e_685e0f8aea388329979afee976eae4ad