### PR TITLE
Filter deleted snapshots

### DIFF
--- a/src/__tests__/HistoricalManager.test.tsx
+++ b/src/__tests__/HistoricalManager.test.tsx
@@ -2,6 +2,7 @@ import 'fake-indexeddb/auto'
 // polyfill for jest environment
 global.structuredClone =
   global.structuredClone || ((v: any) => JSON.parse(JSON.stringify(v)))
+;
 import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import React from 'react'
@@ -29,6 +30,20 @@ describe('HistoricalManager', () => {
         <HistoricalManager />
       </SnapshotProvider>
     )
+    expect(await screen.findByText('2024-01')).toBeInTheDocument()
+  })
+
+  test('filters deleted snapshots', async () => {
+    const { softDeleteSnapshot, addSnapshot } = await import('../services/snapshotStore')
+    const altSnap = { ...baseSnap, checksum: 'y' }
+    await addSnapshot(altSnap as any, '2024-02')
+    await softDeleteSnapshot('2024-02')
+    render(
+      <SnapshotProvider>
+        <HistoricalManager />
+      </SnapshotProvider>
+    )
+    expect(screen.queryByText('2024-02')).not.toBeInTheDocument()
     expect(await screen.findByText('2024-01')).toBeInTheDocument()
   })
 })

--- a/src/contexts/SnapshotContext.tsx
+++ b/src/contexts/SnapshotContext.tsx
@@ -20,7 +20,12 @@ export function SnapshotProvider ({ children }: { children: ReactNode }) {
     liveQuery(getActiveSnapshot)
   )
   const list = useObservable<SnapshotRow[], SnapshotRow[]>(
-    () => liveQuery(() => db.snapshots.toArray()),
+    () =>
+      liveQuery(() =>
+        db.snapshots
+          .filter(row => row.deleted !== true)
+          .toArray()
+      ),
     [],
     []
   )


### PR DESCRIPTION
## Summary
- filter snapshots in context so deleted items don't appear
- cover deleted snapshot filtering in HistoricalManager tests

## Testing
- `CI=true npm test --silent` *(fails: crypto not defined, File.text not a function, snapshot mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_685eb9891b948329a06aa630b850a256