### PR TITLE
Fix duplicate check for deleted snapshots

### DIFF
--- a/src/__tests__/snapshotStore.test.js
+++ b/src/__tests__/snapshotStore.test.js
@@ -54,4 +54,10 @@ describe('snapshotStore', () => {
     expect(row.deleted).toBe(true)
     expect(row.active).toBe(false)
   })
+
+  test('deleted snapshots can be re-added', async () => {
+    await addSnapshot(baseSnap, '2024-06')
+    await softDeleteSnapshot('2024-06')
+    await expect(addSnapshot(baseSnap, '2024-07')).resolves.toBeUndefined()
+  })
 })

--- a/src/services/snapshotStore.ts
+++ b/src/services/snapshotStore.ts
@@ -28,7 +28,9 @@ export async function addSnapshot (
   id: string,
   note: string | null = null
 ): Promise<void> {
-  const duplicate = await db.snapshots.filter(r => r.checksum === snap.checksum).first()
+  const duplicate = await db.snapshots
+    .filter(r => r.checksum === snap.checksum && r.deleted !== true)
+    .first()
   if (duplicate) throw new Error('duplicate checksum')
   const row: SnapshotRow = {
     ...snap,
@@ -56,7 +58,9 @@ export async function setActiveSnapshot (id: string): Promise<void> {
 }
 
 export async function getActiveSnapshot (): Promise<SnapshotRow | undefined> {
-  return await db.snapshots.filter(r => r.active === true).first()
+  return await db.snapshots
+    .filter(r => r.active === true && r.deleted !== true)
+    .first()
 }
 
 export async function softDeleteSnapshot (id: string): Promise<void> {


### PR DESCRIPTION
## Summary
- filter out deleted entries when checking for duplicate snapshot
- avoid deleted rows when fetching active snapshot
- test ability to re-add a snapshot after soft delete

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ed1b4092c8329894b4385c769c6e7