### PR TITLE
Fix duplicate check for deleted snapshots

### DIFF
--- a/src/__tests__/snapshotStore.test.js
+++ b/src/__tests__/snapshotStore.test.js
@@ -54,4 +54,10 @@ describe('snapshotStore', () => {
     expect(row.deleted).toBe(true)
     expect(row.active).toBe(false)
   })
+
+  test('deleted snapshots can be re-added', async () => {
+    await addSnapshot(baseSnap, '2024-06')
+    await softDeleteSnapshot('2024-06')
+    await expect(addSnapshot(baseSnap, '2024-07')).resolves.toBeUndefined()
+  })
 })

--- a/src/components/__tests__/__snapshots__/FundTable.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/FundTable.test.jsx.snap
@@ -175,11 +175,16 @@ exports[`renders table snapshot 1`] = `
             <div
               style="display: flex; flex-wrap: wrap; gap: 0.25rem;"
             >
-              <span
-                style="background-color: rgba(107, 114, 128, 0.125); color: rgb(107, 114, 128); border: 1px solid #6b728040; border-radius: 9999px; font-size: 0.7rem; padding: 0.125rem 0.5rem;"
+              <div
+                class="MuiChip-root MuiChip-outlined MuiChip-sizeSmall MuiChip-colorDefault MuiChip-outlinedDefault css-1d2be57-MuiChip-root"
+                style="background-color: rgba(107, 114, 128, 0.125); color: rgb(107, 114, 128); border-color: #6b728040;"
               >
-                outperformer
-              </span>
+                <span
+                  class="MuiChip-label MuiChip-labelSmall css-19m61dl-MuiChip-label"
+                >
+                  outperformer
+                </span>
+              </div>
             </div>
           </td>
         </tr>

--- a/src/services/snapshotStore.ts
+++ b/src/services/snapshotStore.ts
@@ -28,7 +28,9 @@ export async function addSnapshot (
   id: string,
   note: string | null = null
 ): Promise<void> {
-  const duplicate = await db.snapshots.filter(r => r.checksum === snap.checksum).first()
+  const duplicate = await db.snapshots
+    .filter(r => r.checksum === snap.checksum && r.deleted !== true)
+    .first()
   if (duplicate) throw new Error('duplicate checksum')
   const row: SnapshotRow = {
     ...snap,
@@ -56,7 +58,9 @@ export async function setActiveSnapshot (id: string): Promise<void> {
 }
 
 export async function getActiveSnapshot (): Promise<SnapshotRow | undefined> {
-  return await db.snapshots.filter(r => r.active === true).first()
+  return await db.snapshots
+    .filter(r => r.active === true && r.deleted !== true)
+    .first()
 }
 
 export async function softDeleteSnapshot (id: string): Promise<void> {

--- a/src/utils/__tests__/hash.test.ts
+++ b/src/utils/__tests__/hash.test.ts
@@ -1,8 +1,10 @@
 import { sha1Hex } from '../hash'
 import { TextEncoder } from 'util'
+import { webcrypto as nodeCrypto } from 'crypto'
 
 // polyfill TextEncoder for jsdom environment
-(global as any).TextEncoder = (global as any).TextEncoder || TextEncoder
+(global as any).TextEncoder = (global as any).TextEncoder || TextEncoder;
+(global as any).crypto = (global as any).crypto || nodeCrypto;
 
 describe('sha1Hex', () => {
   it('computes SHA-1 hex for Uint8Array', async () => {


### PR DESCRIPTION
## Summary
- filter out deleted entries when checking for duplicate snapshot
- avoid deleted rows when fetching active snapshot
- test ability to re-add a snapshot after soft delete
- update crypto polyfill for tests and refresh snapshot

## Testing
- `CI=true npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_685ed1b4092c8329894b4385c769c6e7