### PR TITLE
Update docs for IndexedDB transition

### DIFF
--- a/PROJECT_OVERVIEW.md
+++ b/PROJECT_OVERVIEW.md
@@ -80,7 +80,7 @@ Frontend built with React and XLSX.js for Excel parsing
 
 Data is loaded by uploading one file per month: FundPerformance.xlsx
 
-Recommended fund list and benchmark mappings are stored in a local file or localStorage
+Recommended fund list and benchmark mappings are stored in **IndexedDB** (via `dataStore`)
 
 The app has 3 main tabs:
 
@@ -247,7 +247,7 @@ Files to modify: Create src/services/dataStore.js
 Implement:
 
 IndexedDB setup for historical snapshots
-Migration from current localStorage config
+ Migration from legacy localStorage config (🗸 completed Jun 2025)
 Snapshot comparison functions
 Data validation layer
 

--- a/docs/Critical Bug & Stability Sweep.md
+++ b/docs/Critical Bug & Stability Sweep.md
@@ -1,3 +1,7 @@
+> **Note (Jun 2025):**  
+> The code snippets below refer to `localStorage` for historical context.  
+> The app now persists all data and preferences in **IndexedDB** via `src/services/dataStore.js`.
+
 # Lightship Fund Analysis — Bug & Stability Audit
 💡 Run this check on the repo *exactly as it exists now* (don’t assume any other agent’s fixes).
 


### PR DESCRIPTION
## Summary
- clarify where config data is stored in **IndexedDB** via `dataStore`
- mark localStorage migration bullet as complete
- add note about legacy `localStorage` in Critical Bug audit guide

## Testing
- `npm test`
- `npm run typecheck` *(fails: Missing script)*
- `npm run lint:fix` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686195974bc483298c5e7fa32ff18073