### PR TITLE
Add Vite alias and eslint env

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,6 +5,14 @@ import pluginReact from "eslint-plugin-react";
 
 export default [
   js.configs.recommended,
-  { files: ["**/*.{js,mjs,cjs,jsx}"], languageOptions: { globals: globals.browser } },
+  {
+    files: ["**/*.{js,mjs,cjs,jsx}"],
+    languageOptions: {
+      globals: {
+        ...globals.browser,
+        ...globals.es2020,
+      },
+    },
+  },
   pluginReact.configs.flat.recommended,
 ];

--- a/src/services/dataStore.js
+++ b/src/services/dataStore.js
@@ -1,4 +1,3 @@
-/* eslint-env es2020, browser */
 // src/services/dataStore.js
 
 /**

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import { fileURLToPath, URL } from 'node:url'
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url))
+    }
+  }
+})


### PR DESCRIPTION
## Summary
- configure Vite to resolve `@/` to `src`
- extend ESLint globals so `globalThis` is allowed
- drop per-file env comment from `dataStore.js`

## How to Test
- `npm test` *(fails: react-scripts missing)*
- `npm run typecheck` *(fails: missing script)*
- `npm run lint:fix` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686297df220883299ff79889075b716a