### PR TITLE
Fix CRA build imports and ESLint env

### DIFF
--- a/src/services/dataStore.js
+++ b/src/services/dataStore.js
@@ -1,3 +1,4 @@
+/* eslint-env browser, es2020 */
 // src/services/dataStore.js
 
 /**

--- a/src/services/scoring.js
+++ b/src/services/scoring.js
@@ -6,7 +6,7 @@
  */
 
 import { getScoreColor, getScoreLabel } from '../utils/scoreTags';
-import { CURRENT_PERFORMANCE_HEADERS as CUR } from '@/docs/schema'
+import { CURRENT_PERFORMANCE_HEADERS as CUR } from '../docs/schema'
 
 // Metric weights configuration - these match your Word document
 const METRIC_WEIGHTS = {

--- a/src/utils/headerMap.ts
+++ b/src/utils/headerMap.ts
@@ -1,4 +1,4 @@
-import { CURRENT_PERFORMANCE_HEADERS, HISTORICAL_PERFORMANCE_HEADERS, type FundMetrics, type KnownCsvHeader } from '@/docs/schema'
+import { CURRENT_PERFORMANCE_HEADERS, HISTORICAL_PERFORMANCE_HEADERS, type FundMetrics, type KnownCsvHeader } from '../docs/schema'
 
 export type NormalizedRow = Partial<FundMetrics>
 

--- a/src/utils/parseFundFile.ts
+++ b/src/utils/parseFundFile.ts
@@ -6,7 +6,7 @@ import { loadAssetClassMap, lookupAssetClass } from '../services/dataLoader.js'
 import {
   CURRENT_PERFORMANCE_HEADERS as CUR,
   HISTORICAL_PERFORMANCE_HEADERS as HIST,
-} from '@/docs/schema';
+} from '../docs/schema';
 
 export const COLUMN_MAP: Record<string, keyof NormalisedRow> = {
   'Symbol': 'symbol',


### PR DESCRIPTION
## What
- use relative imports for schema module
- add eslint-env header for browser environment in dataStore.js

## How to Test
- `npm test`
- `npm run typecheck` *(fails: missing script)*
- `npm run lint:fix` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68629c89f9c48329934084fc0369338d