### PR TITLE
Convert tables & filters to Tailwind

### DIFF
--- a/src/components/BenchmarkRow.jsx
+++ b/src/components/BenchmarkRow.jsx
@@ -7,18 +7,8 @@ const ScoreBadge = ({ score }) => {
   const label = getScoreLabel(score);
   return (
     <span
-      style={{
-        backgroundColor: `${color}20`,
-        color,
-        border: `1px solid ${color}50`,
-        borderRadius: '9999px',
-        fontSize: '0.75rem',
-        fontWeight: 'bold',
-        padding: '0.25rem 0.5rem',
-        display: 'inline-block',
-        minWidth: '3rem',
-        textAlign: 'center'
-      }}
+      style={{ backgroundColor: `${color}20`, color, borderColor: `${color}50` }}
+      className="inline-block min-w-[3rem] rounded-full border px-2 py-1 text-center text-xs font-bold"
     >
       {Number(score).toFixed(1)} - {label}
     </span>
@@ -29,41 +19,41 @@ const BenchmarkRow = ({ fund }) => {
   const row = fund;
   if (!row) return null;
   return (
-    <tr className="benchmark-banner">
-      <td style={{ padding: '0.75rem' }}>{`Benchmark — ${row.Symbol}`}</td>
-      <td style={{ padding: '0.75rem' }}>{row.fundName || row.name}</td>
-      <td style={{ padding: '0.75rem' }}>Benchmark</td>
-      <td style={{ padding: '0.75rem', textAlign: 'center' }}>
+    <tr className="bg-slate-100 font-medium">
+      <td className="px-3 py-3">{`Benchmark — ${row.Symbol}`}</td>
+      <td className="px-3 py-3">{row.fundName || row.name}</td>
+      <td className="px-3 py-3">Benchmark</td>
+      <td className="px-3 py-3 text-center">
         {row.score != null
           ? <ScoreBadge score={row.score} />
           : row.scores
             ? <ScoreBadge score={row.scores.final} />
             : '-'}
       </td>
-      <td style={{ padding: '0.75rem' }}></td>
-      <td style={{ padding: '0.75rem' }}></td>
-      <td style={{ padding: '0.75rem', textAlign: 'right' }}>
+      <td className="px-3 py-3"></td>
+      <td className="px-3 py-3"></td>
+      <td className="px-3 py-3 text-right">
         {fmtPct(row.ytd ?? row.YTD)}
       </td>
-      <td style={{ padding: '0.75rem', textAlign: 'right' }}>
+      <td className="px-3 py-3 text-right">
         {fmtPct(row.oneYear)}
       </td>
-      <td style={{ padding: '0.75rem', textAlign: 'right' }}>
+      <td className="px-3 py-3 text-right">
         {fmtPct(row.threeYear)}
       </td>
-      <td style={{ padding: '0.75rem', textAlign: 'right' }}>
+      <td className="px-3 py-3 text-right">
         {fmtPct(row.fiveYear)}
       </td>
-      <td style={{ padding: '0.75rem', textAlign: 'right' }}>
+      <td className="px-3 py-3 text-right">
         {fmtNumber(row.sharpe3y)}
       </td>
-      <td style={{ padding: '0.75rem', textAlign: 'right' }}>
+      <td className="px-3 py-3 text-right">
         {fmtPct(row.stdDev5y)}
       </td>
-      <td style={{ padding: '0.75rem', textAlign: 'right' }}>
+      <td className="px-3 py-3 text-right">
         {fmtPct(row.expenseRatio)}
       </td>
-      <td style={{ padding: '0.75rem' }}></td>
+      <td className="px-3 py-3"></td>
     </tr>
   );
 };

--- a/src/components/ClassView.css
+++ b/src/components/ClassView.css
@@ -1,8 +1,0 @@
-.benchmark-banner {
-  background: #f1f5f9; /* slate-100 */
-  border-radius: 0.5rem;
-  padding: 0.5rem 0.75rem;
-  margin-bottom: 0.25rem;
-  font-weight: 500;
-}
-

--- a/src/components/Filters/GlobalFilterBar.jsx
+++ b/src/components/Filters/GlobalFilterBar.jsx
@@ -47,28 +47,15 @@ const GlobalFilterBar = ({
     tag.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
 
   return (
-    <div
-      style={{
-        display: 'flex',
-        flexWrap: 'wrap',
-        alignItems: 'flex-end',
-        gap: '1rem',
-        padding: '0.75rem 0'
-      }}
-    >
-      <div style={{ display: 'flex', flexDirection: 'column' }}>
-        <label style={{ fontSize: '0.875rem', marginBottom: '0.25rem' }}>
+    <div className="flex flex-wrap items-end gap-4 py-3">
+      <div className="flex flex-col">
+        <label className="mb-1 text-sm">
           Asset Class
         </label>
         <select
           value={selectedClass || ''}
           onChange={handleClassChange}
-          style={{
-            minWidth: '160px',
-            padding: '0.5rem',
-            border: '1px solid #d1d5db',
-            borderRadius: '0.375rem'
-          }}
+          className="min-w-[160px] rounded border border-gray-300 p-2"
         >
           <option value=''>All Classes</option>
           {availableClasses.slice().sort().map(cls => (
@@ -77,20 +64,15 @@ const GlobalFilterBar = ({
         </select>
       </div>
 
-      <div style={{ display: 'flex', flexDirection: 'column' }}>
-        <label style={{ fontSize: '0.875rem', marginBottom: '0.25rem' }}>
+      <div className="flex flex-col">
+        <label className="mb-1 text-sm">
           Tags
         </label>
         <select
           multiple
           value={selectedTags}
           onChange={handleTagChange}
-          style={{
-            minWidth: '200px',
-            padding: '0.5rem',
-            border: '1px solid #d1d5db',
-            borderRadius: '0.375rem'
-          }}
+          className="min-w-[200px] rounded border border-gray-300 p-2"
         >
           {availableTags.slice().sort().map(tag => (
             <option key={tag} value={tag}>{formatTag(tag)}</option>
@@ -100,14 +82,7 @@ const GlobalFilterBar = ({
 
       <button
         onClick={() => typeof onReset === 'function' && onReset()}
-        style={{
-          padding: '0.5rem 1rem',
-          backgroundColor: '#e5e7eb',
-          border: '1px solid #d1d5db',
-          borderRadius: '0.375rem',
-          cursor: 'pointer',
-          fontSize: '0.875rem'
-        }}
+        className="rounded border border-gray-300 bg-gray-200 px-4 py-2 text-sm"
       >
         Reset Filters
       </button>

--- a/src/components/Filters/TagFilterBar.jsx
+++ b/src/components/Filters/TagFilterBar.jsx
@@ -20,19 +20,7 @@ const TagFilterBar = () => {
   };
 
   return (
-    <div
-      style={{
-        position: 'sticky',
-        top: 0,
-        zIndex: 20,
-        background: 'white',
-        padding: '0.5rem',
-        borderBottom: '1px solid #e5e7eb',
-        display: 'flex',
-        flexWrap: 'wrap',
-        gap: '0.5rem'
-      }}
-    >
+    <div className="sticky top-0 z-20 flex flex-wrap gap-2 border-b border-gray-200 bg-white p-2">
       {TAGS.map(tag => {
         const active = selectedTags.includes(tag);
         return (
@@ -40,16 +28,7 @@ const TagFilterBar = () => {
             key={tag}
             type="button"
             onClick={() => handleToggle(tag)}
-            style={{
-              cursor: 'pointer',
-              borderRadius: '9999px',
-              padding: '0.25rem 0.75rem',
-              fontSize: '0.75rem',
-              border: `1px solid ${active ? '#2563eb' : '#d1d5db'}`,
-              backgroundColor: active ? '#2563eb20' : 'transparent',
-              color: active ? '#2563eb' : '#374151',
-              fontWeight: active ? 600 : 400
-            }}
+            className={`cursor-pointer rounded-full border px-3 py-1 text-xs ${active ? 'border-blue-600 bg-blue-600/20 text-blue-600 font-semibold' : 'border-gray-300 text-gray-700'}`}
           >
             {tag}
           </button>
@@ -58,13 +37,7 @@ const TagFilterBar = () => {
       <button
         type="button"
         onClick={() => resetFilters && resetFilters()}
-        style={{
-          cursor: 'pointer',
-          borderRadius: '9999px',
-          padding: '0.25rem 0.75rem',
-          fontSize: '0.75rem',
-          border: '1px solid #d1d5db'
-        }}
+        className="cursor-pointer rounded-full border border-gray-300 px-3 py-1 text-xs"
       >
         Clear
       </button>

--- a/src/components/Filters/TagFilterPanel.jsx
+++ b/src/components/Filters/TagFilterPanel.jsx
@@ -22,7 +22,7 @@ const TagFilterPanel = ({ availableTags = [], selectedTags = [], onToggleTag }) 
   };
 
   return (
-    <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem' }}>
+    <div className="flex flex-wrap gap-2">
       {availableTags.map(tag => {
         const active = Array.isArray(selectedTags) && selectedTags.includes(tag);
         const color  = TAG_COLORS[tag] || '#6b7280';
@@ -33,15 +33,11 @@ const TagFilterPanel = ({ availableTags = [], selectedTags = [], onToggleTag }) 
             type="button"
             onClick={() => handleToggle(tag)}
             style={{
-              cursor         : 'pointer',
-              borderRadius   : '9999px',
-              padding        : '0.25rem 0.75rem',
-              fontSize       : '0.75rem',
-              border         : `1px solid ${active ? color : '#d1d5db'}`,
+              borderColor: active ? color : '#d1d5db',
               backgroundColor: active ? `${color}20` : 'transparent',
-              color          : active ? color : '#374151',
-              fontWeight     : active ? 600 : 400
+              color: active ? color : '#374151'
             }}
+            className={`cursor-pointer rounded-full border px-3 py-1 text-xs ${active ? 'font-semibold' : ''}`}
           >
             {tag}
           </button>

--- a/src/components/FundTable.jsx
+++ b/src/components/FundTable.jsx
@@ -16,15 +16,9 @@ const ScoreBadge = ({ score }) => {
       style={{
         backgroundColor: `${color}20`,
         color,
-        border: `1px solid ${color}50`,
-        borderRadius: '9999px',
-        fontSize: '0.75rem',
-        fontWeight: 'bold',
-        padding: '0.25rem 0.5rem',
-        display: 'inline-block',
-        minWidth: '3rem',
-        textAlign: 'center'
+        borderColor: `${color}50`
       }}
+      className="inline-block min-w-[3rem] rounded-full border px-2 py-1 text-center text-xs font-bold"
     >
       {Number(score).toFixed(1)} - {label}
     </span>
@@ -85,20 +79,20 @@ const FundTable = ({ funds = [], rows, benchmark, onRowClick = () => {}, deltas 
   }, [data, sort]);
 
   return (
-    <div style={{ overflowX: 'auto' }}>
-      <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+    <div className="overflow-x-auto">
+      <table className="w-full border-collapse">
       <colgroup>
         {columns.map((c, idx) => (
           <col key={idx} />
         ))}
       </colgroup>
       <thead>
-        <tr style={{ borderBottom: '2px solid #e5e7eb' }}>
+        <tr className="border-b-2 border-gray-200">
           {columns.map(col => (
             <th
               key={col.key}
               onClick={() => handleSort(col.key, col.numeric)}
-              style={{ padding: '0.75rem', textAlign: col.numeric ? 'right' : col.key === 'Score' ? 'center' : 'left', fontWeight: 500, cursor: 'pointer' }}
+              className={`cursor-pointer p-3 font-medium ${col.numeric ? 'text-right' : col.key === 'Score' ? 'text-center' : 'text-left'}`}
             >
               {col.label}
               {sort.key === col.key && (sort.dir === 'asc' ? ' ▲' : ' ▼')}
@@ -111,29 +105,25 @@ const FundTable = ({ funds = [], rows, benchmark, onRowClick = () => {}, deltas 
         {sorted.map(fund => (
           <tr
             key={fund.Symbol}
-            style={{
-              borderBottom: '1px solid #f3f4f6',
-              cursor: 'pointer',
-              backgroundColor: fund.isBenchmark ? '#fffbeb' : 'transparent'
-            }}
+            className={`border-b border-gray-100 cursor-pointer ${fund.isBenchmark ? 'bg-amber-50' : ''}`}
             role="button"
             tabIndex={0}
             onKeyDown={e => e.key === 'Enter' && onRowClick(fund)}
             onClick={() => onRowClick(fund)}
           >
-            <td style={{ padding: '0.5rem' }}>{fund.Symbol}</td>
-            <td style={{ padding: '0.5rem' }}>{fund.fundName}</td>
-            <td style={{ padding: '0.5rem' }}>
+            <td className="p-2">{fund.Symbol}</td>
+            <td className="p-2">{fund.fundName}</td>
+            <td className="p-2">
               {fund.isBenchmark ? 'Benchmark' : fund.isRecommended ? 'Recommended' : ''}
             </td>
-            <td style={{ padding: '0.5rem', textAlign: 'center' }}>
+            <td className="p-2 text-center">
               {fund.score != null
                 ? <ScoreBadge score={fund.score} />
                 : fund.scores
                   ? <ScoreBadge score={fund.scores.final} />
                   : '—'}
             </td>
-            <td style={{ padding: '0.5rem', textAlign: 'center' }}>
+            <td className="p-2 text-center">
               {(() => {
                 const d = deltas[fund.Symbol]
                 return d == null ? '' : d > 0
@@ -143,35 +133,35 @@ const FundTable = ({ funds = [], rows, benchmark, onRowClick = () => {}, deltas 
                     : '—'
               })()}
             </td>
-            <td style={{ padding: '0.5rem' }}>
+            <td className="p-2">
               <SparkLine data={spark[fund.Symbol] ?? []} />
             </td>
-            <td style={{ padding: '0.5rem', textAlign: 'right' }}>
+            <td className="p-2 text-right">
               {fmtPct(fund.ytd)}
             </td>
-            <td style={{ padding: '0.5rem', textAlign: 'right' }}>
+            <td className="p-2 text-right">
               {fmtPct(fund.oneYear)}
             </td>
-            <td style={{ padding: '0.5rem', textAlign: 'right' }}>
+            <td className="p-2 text-right">
               {fmtPct(fund.threeYear)}
             </td>
-            <td style={{ padding: '0.5rem', textAlign: 'right' }}>
+            <td className="p-2 text-right">
               {fmtPct(fund.fiveYear)}
             </td>
-            <td style={{ padding: '0.5rem', textAlign: 'right' }}>
+            <td className="p-2 text-right">
               {fmtNumber(fund.sharpe3y)}
             </td>
-            <td style={{ padding: '0.5rem', textAlign: 'right' }}>
+            <td className="p-2 text-right">
               {fmtPct(fund.stdDev5y)}
             </td>
-            <td style={{ padding: '0.5rem', textAlign: 'right' }}>
+            <td className="p-2 text-right">
               {fmtPct(fund.expenseRatio)}
             </td>
-            <td style={{ padding: '0.5rem' }}>
+            <td className="p-2">
               {Array.isArray(fund.tags) && fund.tags.length > 0 ? (
                 <TagList tags={fund.tags} />
               ) : (
-                <span style={{ color: '#9ca3af' }}>-</span>
+                <span className="text-gray-400">-</span>
               )}
             </td>
           </tr>

--- a/src/routes/ClassView.tsx
+++ b/src/routes/ClassView.tsx
@@ -2,7 +2,6 @@ import React, { useMemo } from 'react'
 import FundTable from '../components/FundTable.jsx'
 import { useSnapshot } from '../contexts/SnapshotContext'
 import { NormalisedRow } from '../utils/parseFundFile'
-import '../components/ClassView.css'
 
 interface Props {
   defaultAssetClass?: string


### PR DESCRIPTION
## Summary
- switch inline styles in FundTable and BenchmarkRow to Tailwind classes
- refactor GlobalFilterBar and tag filters to use Tailwind
- drop unused ClassView.css

## How to Test
- `npm start` and load the app
- verify FundTable and BenchmarkRow layout looks correct
- verify tag and global filter bars render and work normally


------
https://chatgpt.com/codex/tasks/task_e_6863e8ed8ea483299954485d62e687eb