### PR TITLE
Refactor tables to Tailwind classes

### DIFF
--- a/src/components/BenchmarkRow.jsx
+++ b/src/components/BenchmarkRow.jsx
@@ -2,23 +2,21 @@ import React from 'react';
 import { getScoreColor, getScoreLabel } from '../utils/scoreTags';
 import { fmtPct, fmtNumber } from '../utils/formatters';
 
+const COLOR_MAP = {
+  '#16a34a': 'green-600',
+  '#22c55e': 'green-500',
+  '#6b7280': 'gray-500',
+  '#eab308': 'yellow-500',
+  '#dc2626': 'red-600'
+};
+
 const ScoreBadge = ({ score }) => {
   const color = getScoreColor(score);
   const label = getScoreLabel(score);
+  const tone = COLOR_MAP[color] || 'gray-500';
   return (
     <span
-      style={{
-        backgroundColor: `${color}20`,
-        color,
-        border: `1px solid ${color}50`,
-        borderRadius: '9999px',
-        fontSize: '0.75rem',
-        fontWeight: 'bold',
-        padding: '0.25rem 0.5rem',
-        display: 'inline-block',
-        minWidth: '3rem',
-        textAlign: 'center'
-      }}
+      className={`inline-block min-w-[3rem] rounded-full border px-2 py-1 text-center text-xs font-bold bg-${tone}/20 border-${tone}/50 text-${tone}`}
     >
       {Number(score).toFixed(1)} - {label}
     </span>
@@ -30,40 +28,40 @@ const BenchmarkRow = ({ fund }) => {
   if (!row) return null;
   return (
     <tr className="benchmark-banner">
-      <td style={{ padding: '0.75rem' }}>{`Benchmark — ${row.Symbol}`}</td>
-      <td style={{ padding: '0.75rem' }}>{row.fundName || row.name}</td>
-      <td style={{ padding: '0.75rem' }}>Benchmark</td>
-      <td style={{ padding: '0.75rem', textAlign: 'center' }}>
+      <td className="p-3">{`Benchmark — ${row.Symbol}`}</td>
+      <td className="p-3">{row.fundName || row.name}</td>
+      <td className="p-3">Benchmark</td>
+      <td className="p-3 text-center">
         {row.score != null
           ? <ScoreBadge score={row.score} />
           : row.scores
             ? <ScoreBadge score={row.scores.final} />
             : '-'}
       </td>
-      <td style={{ padding: '0.75rem' }}></td>
-      <td style={{ padding: '0.75rem' }}></td>
-      <td style={{ padding: '0.75rem', textAlign: 'right' }}>
+      <td className="p-3"></td>
+      <td className="p-3"></td>
+      <td className="p-3 text-right">
         {fmtPct(row.ytd ?? row.YTD)}
       </td>
-      <td style={{ padding: '0.75rem', textAlign: 'right' }}>
+      <td className="p-3 text-right">
         {fmtPct(row.oneYear)}
       </td>
-      <td style={{ padding: '0.75rem', textAlign: 'right' }}>
+      <td className="p-3 text-right">
         {fmtPct(row.threeYear)}
       </td>
-      <td style={{ padding: '0.75rem', textAlign: 'right' }}>
+      <td className="p-3 text-right">
         {fmtPct(row.fiveYear)}
       </td>
-      <td style={{ padding: '0.75rem', textAlign: 'right' }}>
+      <td className="p-3 text-right">
         {fmtNumber(row.sharpe3y)}
       </td>
-      <td style={{ padding: '0.75rem', textAlign: 'right' }}>
+      <td className="p-3 text-right">
         {fmtPct(row.stdDev5y)}
       </td>
-      <td style={{ padding: '0.75rem', textAlign: 'right' }}>
+      <td className="p-3 text-right">
         {fmtPct(row.expenseRatio)}
       </td>
-      <td style={{ padding: '0.75rem' }}></td>
+      <td className="p-3"></td>
     </tr>
   );
 };

--- a/src/components/Filters/GlobalFilterBar.jsx
+++ b/src/components/Filters/GlobalFilterBar.jsx
@@ -47,28 +47,15 @@ const GlobalFilterBar = ({
     tag.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
 
   return (
-    <div
-      style={{
-        display: 'flex',
-        flexWrap: 'wrap',
-        alignItems: 'flex-end',
-        gap: '1rem',
-        padding: '0.75rem 0'
-      }}
-    >
-      <div style={{ display: 'flex', flexDirection: 'column' }}>
-        <label style={{ fontSize: '0.875rem', marginBottom: '0.25rem' }}>
+    <div className="flex flex-wrap items-end gap-4 py-3">
+      <div className="flex flex-col">
+        <label className="text-sm mb-1">
           Asset Class
         </label>
         <select
           value={selectedClass || ''}
           onChange={handleClassChange}
-          style={{
-            minWidth: '160px',
-            padding: '0.5rem',
-            border: '1px solid #d1d5db',
-            borderRadius: '0.375rem'
-          }}
+          className="min-w-[160px] p-2 border border-gray-300 rounded-md"
         >
           <option value=''>All Classes</option>
           {availableClasses.slice().sort().map(cls => (
@@ -77,37 +64,24 @@ const GlobalFilterBar = ({
         </select>
       </div>
 
-      <div style={{ display: 'flex', flexDirection: 'column' }}>
-        <label style={{ fontSize: '0.875rem', marginBottom: '0.25rem' }}>
+      <div className="flex flex-col">
+        <label className="text-sm mb-1">
           Tags
         </label>
         <select
           multiple
           value={selectedTags}
           onChange={handleTagChange}
-          style={{
-            minWidth: '200px',
-            padding: '0.5rem',
-            border: '1px solid #d1d5db',
-            borderRadius: '0.375rem'
-          }}
+          className="min-w-[200px] p-2 border border-gray-300 rounded-md"
         >
           {availableTags.slice().sort().map(tag => (
             <option key={tag} value={tag}>{formatTag(tag)}</option>
           ))}
         </select>
       </div>
-
       <button
         onClick={() => typeof onReset === 'function' && onReset()}
-        style={{
-          padding: '0.5rem 1rem',
-          backgroundColor: '#e5e7eb',
-          border: '1px solid #d1d5db',
-          borderRadius: '0.375rem',
-          cursor: 'pointer',
-          fontSize: '0.875rem'
-        }}
+        className="px-4 py-2 bg-gray-200 border border-gray-300 rounded-md cursor-pointer text-sm"
       >
         Reset Filters
       </button>

--- a/src/components/Filters/TagFilterBar.jsx
+++ b/src/components/Filters/TagFilterBar.jsx
@@ -20,19 +20,7 @@ const TagFilterBar = () => {
   };
 
   return (
-    <div
-      style={{
-        position: 'sticky',
-        top: 0,
-        zIndex: 20,
-        background: 'white',
-        padding: '0.5rem',
-        borderBottom: '1px solid #e5e7eb',
-        display: 'flex',
-        flexWrap: 'wrap',
-        gap: '0.5rem'
-      }}
-    >
+    <div className="sticky top-0 z-20 bg-white p-2 border-b border-gray-200 flex flex-wrap gap-2">
       {TAGS.map(tag => {
         const active = selectedTags.includes(tag);
         return (
@@ -40,16 +28,11 @@ const TagFilterBar = () => {
             key={tag}
             type="button"
             onClick={() => handleToggle(tag)}
-            style={{
-              cursor: 'pointer',
-              borderRadius: '9999px',
-              padding: '0.25rem 0.75rem',
-              fontSize: '0.75rem',
-              border: `1px solid ${active ? '#2563eb' : '#d1d5db'}`,
-              backgroundColor: active ? '#2563eb20' : 'transparent',
-              color: active ? '#2563eb' : '#374151',
-              fontWeight: active ? 600 : 400
-            }}
+            className={`cursor-pointer rounded-full px-3 py-1 text-xs border ${
+              active
+                ? 'border-blue-600 bg-blue-600/20 text-blue-600 font-semibold'
+                : 'border-gray-300 text-gray-700'
+            }`}
           >
             {tag}
           </button>
@@ -58,13 +41,7 @@ const TagFilterBar = () => {
       <button
         type="button"
         onClick={() => resetFilters && resetFilters()}
-        style={{
-          cursor: 'pointer',
-          borderRadius: '9999px',
-          padding: '0.25rem 0.75rem',
-          fontSize: '0.75rem',
-          border: '1px solid #d1d5db'
-        }}
+        className="cursor-pointer rounded-full px-3 py-1 text-xs border border-gray-300"
       >
         Clear
       </button>

--- a/src/components/FundTable.jsx
+++ b/src/components/FundTable.jsx
@@ -8,23 +8,21 @@ import SparkLine from './SparkLine';
 import ArrowDropUpIcon from '@mui/icons-material/ArrowDropUp';
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 
+const COLOR_MAP = {
+  '#16a34a': 'green-600',
+  '#22c55e': 'green-500',
+  '#6b7280': 'gray-500',
+  '#eab308': 'yellow-500',
+  '#dc2626': 'red-600'
+};
+
 const ScoreBadge = ({ score }) => {
   const color = getScoreColor(score);
   const label = getScoreLabel(score);
+  const tone = COLOR_MAP[color] || 'gray-500';
   return (
     <span
-      style={{
-        backgroundColor: `${color}20`,
-        color,
-        border: `1px solid ${color}50`,
-        borderRadius: '9999px',
-        fontSize: '0.75rem',
-        fontWeight: 'bold',
-        padding: '0.25rem 0.5rem',
-        display: 'inline-block',
-        minWidth: '3rem',
-        textAlign: 'center'
-      }}
+      className={`inline-block min-w-[3rem] rounded-full border px-2 py-1 text-center text-xs font-bold bg-${tone}/20 border-${tone}/50 text-${tone}`}
     >
       {Number(score).toFixed(1)} - {label}
     </span>
@@ -85,20 +83,22 @@ const FundTable = ({ funds = [], rows, benchmark, onRowClick = () => {}, deltas 
   }, [data, sort]);
 
   return (
-    <div style={{ overflowX: 'auto' }}>
-      <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+    <div className="overflow-x-auto">
+      <table className="w-full border-collapse">
       <colgroup>
         {columns.map((c, idx) => (
           <col key={idx} />
         ))}
       </colgroup>
       <thead>
-        <tr style={{ borderBottom: '2px solid #e5e7eb' }}>
+        <tr className="border-b-2 border-gray-200">
           {columns.map(col => (
             <th
               key={col.key}
               onClick={() => handleSort(col.key, col.numeric)}
-              style={{ padding: '0.75rem', textAlign: col.numeric ? 'right' : col.key === 'Score' ? 'center' : 'left', fontWeight: 500, cursor: 'pointer' }}
+              className={`p-3 font-medium cursor-pointer ${
+                col.numeric ? 'text-right' : col.key === 'Score' ? 'text-center' : 'text-left'
+              }`}
             >
               {col.label}
               {sort.key === col.key && (sort.dir === 'asc' ? ' ▲' : ' ▼')}
@@ -111,29 +111,27 @@ const FundTable = ({ funds = [], rows, benchmark, onRowClick = () => {}, deltas 
         {sorted.map(fund => (
           <tr
             key={fund.Symbol}
-            style={{
-              borderBottom: '1px solid #f3f4f6',
-              cursor: 'pointer',
-              backgroundColor: fund.isBenchmark ? '#fffbeb' : 'transparent'
-            }}
+            className={`border-b border-gray-100 cursor-pointer ${
+              fund.isBenchmark ? 'bg-yellow-50' : ''
+            }`}
             role="button"
             tabIndex={0}
             onKeyDown={e => e.key === 'Enter' && onRowClick(fund)}
             onClick={() => onRowClick(fund)}
           >
-            <td style={{ padding: '0.5rem' }}>{fund.Symbol}</td>
-            <td style={{ padding: '0.5rem' }}>{fund.fundName}</td>
-            <td style={{ padding: '0.5rem' }}>
+            <td className="p-2">{fund.Symbol}</td>
+            <td className="p-2">{fund.fundName}</td>
+            <td className="p-2">
               {fund.isBenchmark ? 'Benchmark' : fund.isRecommended ? 'Recommended' : ''}
             </td>
-            <td style={{ padding: '0.5rem', textAlign: 'center' }}>
+            <td className="p-2 text-center">
               {fund.score != null
                 ? <ScoreBadge score={fund.score} />
                 : fund.scores
                   ? <ScoreBadge score={fund.scores.final} />
                   : '—'}
             </td>
-            <td style={{ padding: '0.5rem', textAlign: 'center' }}>
+            <td className="p-2 text-center">
               {(() => {
                 const d = deltas[fund.Symbol]
                 return d == null ? '' : d > 0
@@ -143,35 +141,35 @@ const FundTable = ({ funds = [], rows, benchmark, onRowClick = () => {}, deltas 
                     : '—'
               })()}
             </td>
-            <td style={{ padding: '0.5rem' }}>
+            <td className="p-2">
               <SparkLine data={spark[fund.Symbol] ?? []} />
             </td>
-            <td style={{ padding: '0.5rem', textAlign: 'right' }}>
+            <td className="p-2 text-right">
               {fmtPct(fund.ytd)}
             </td>
-            <td style={{ padding: '0.5rem', textAlign: 'right' }}>
+            <td className="p-2 text-right">
               {fmtPct(fund.oneYear)}
             </td>
-            <td style={{ padding: '0.5rem', textAlign: 'right' }}>
+            <td className="p-2 text-right">
               {fmtPct(fund.threeYear)}
             </td>
-            <td style={{ padding: '0.5rem', textAlign: 'right' }}>
+            <td className="p-2 text-right">
               {fmtPct(fund.fiveYear)}
             </td>
-            <td style={{ padding: '0.5rem', textAlign: 'right' }}>
+            <td className="p-2 text-right">
               {fmtNumber(fund.sharpe3y)}
             </td>
-            <td style={{ padding: '0.5rem', textAlign: 'right' }}>
+            <td className="p-2 text-right">
               {fmtPct(fund.stdDev5y)}
             </td>
-            <td style={{ padding: '0.5rem', textAlign: 'right' }}>
+            <td className="p-2 text-right">
               {fmtPct(fund.expenseRatio)}
             </td>
-            <td style={{ padding: '0.5rem' }}>
+            <td className="p-2">
               {Array.isArray(fund.tags) && fund.tags.length > 0 ? (
                 <TagList tags={fund.tags} />
               ) : (
-                <span style={{ color: '#9ca3af' }}>-</span>
+                <span className="text-gray-400">-</span>
               )}
             </td>
           </tr>

--- a/src/components/__tests__/__snapshots__/ClassView.alignment.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/ClassView.alignment.test.jsx.snap
@@ -6,10 +6,10 @@ exports[`benchmark row aligns with table 1`] = `
     class="class-view"
   >
     <div
-      style="overflow-x: auto;"
+      class="overflow-x-auto"
     >
       <table
-        style="width: 100%; border-collapse: collapse;"
+        class="w-full border-collapse"
       >
         <colgroup>
           <col />
@@ -29,75 +29,75 @@ exports[`benchmark row aligns with table 1`] = `
         </colgroup>
         <thead>
           <tr
-            style="border-bottom: 2px solid #e5e7eb;"
+            class="border-b-2 border-gray-200"
           >
             <th
-              style="padding: 0.75rem; text-align: left; font-weight: 500; cursor: pointer;"
+              class="p-3 font-medium cursor-pointer text-left"
             >
               Symbol
             </th>
             <th
-              style="padding: 0.75rem; text-align: left; font-weight: 500; cursor: pointer;"
+              class="p-3 font-medium cursor-pointer text-left"
             >
               Fund Name
             </th>
             <th
-              style="padding: 0.75rem; text-align: left; font-weight: 500; cursor: pointer;"
+              class="p-3 font-medium cursor-pointer text-left"
             >
               Type
             </th>
             <th
-              style="padding: 0.75rem; text-align: right; font-weight: 500; cursor: pointer;"
+              class="p-3 font-medium cursor-pointer text-right"
             >
               Score
             </th>
             <th
-              style="padding: 0.75rem; text-align: right; font-weight: 500; cursor: pointer;"
+              class="p-3 font-medium cursor-pointer text-right"
             >
               Δ
             </th>
             <th
-              style="padding: 0.75rem; text-align: left; font-weight: 500; cursor: pointer;"
+              class="p-3 font-medium cursor-pointer text-left"
             >
               Trend
             </th>
             <th
-              style="padding: 0.75rem; text-align: right; font-weight: 500; cursor: pointer;"
+              class="p-3 font-medium cursor-pointer text-right"
             >
               YTD
             </th>
             <th
-              style="padding: 0.75rem; text-align: right; font-weight: 500; cursor: pointer;"
+              class="p-3 font-medium cursor-pointer text-right"
             >
               1Y
             </th>
             <th
-              style="padding: 0.75rem; text-align: right; font-weight: 500; cursor: pointer;"
+              class="p-3 font-medium cursor-pointer text-right"
             >
               3Y
             </th>
             <th
-              style="padding: 0.75rem; text-align: right; font-weight: 500; cursor: pointer;"
+              class="p-3 font-medium cursor-pointer text-right"
             >
               5Y
             </th>
             <th
-              style="padding: 0.75rem; text-align: right; font-weight: 500; cursor: pointer;"
+              class="p-3 font-medium cursor-pointer text-right"
             >
               Sharpe
             </th>
             <th
-              style="padding: 0.75rem; text-align: right; font-weight: 500; cursor: pointer;"
+              class="p-3 font-medium cursor-pointer text-right"
             >
               Std Dev (5Y)
             </th>
             <th
-              style="padding: 0.75rem; text-align: right; font-weight: 500; cursor: pointer;"
+              class="p-3 font-medium cursor-pointer text-right"
             >
               Expense
             </th>
             <th
-              style="padding: 0.75rem; text-align: left; font-weight: 500; cursor: pointer;"
+              class="p-3 font-medium cursor-pointer text-left"
             >
               Tags
             </th>

--- a/src/components/__tests__/__snapshots__/FundTable.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/FundTable.test.jsx.snap
@@ -3,10 +3,10 @@
 exports[`renders table snapshot 1`] = `
 <DocumentFragment>
   <div
-    style="overflow-x: auto;"
+    class="overflow-x-auto"
   >
     <table
-      style="width: 100%; border-collapse: collapse;"
+      class="w-full border-collapse"
     >
       <colgroup>
         <col />
@@ -26,75 +26,75 @@ exports[`renders table snapshot 1`] = `
       </colgroup>
       <thead>
         <tr
-          style="border-bottom: 2px solid #e5e7eb;"
+          class="border-b-2 border-gray-200"
         >
           <th
-            style="padding: 0.75rem; text-align: left; font-weight: 500; cursor: pointer;"
+            class="p-3 font-medium cursor-pointer text-left"
           >
             Symbol
           </th>
           <th
-            style="padding: 0.75rem; text-align: left; font-weight: 500; cursor: pointer;"
+            class="p-3 font-medium cursor-pointer text-left"
           >
             Fund Name
           </th>
           <th
-            style="padding: 0.75rem; text-align: left; font-weight: 500; cursor: pointer;"
+            class="p-3 font-medium cursor-pointer text-left"
           >
             Type
           </th>
           <th
-            style="padding: 0.75rem; text-align: right; font-weight: 500; cursor: pointer;"
+            class="p-3 font-medium cursor-pointer text-right"
           >
             Score
           </th>
           <th
-            style="padding: 0.75rem; text-align: right; font-weight: 500; cursor: pointer;"
+            class="p-3 font-medium cursor-pointer text-right"
           >
             Δ
           </th>
           <th
-            style="padding: 0.75rem; text-align: left; font-weight: 500; cursor: pointer;"
+            class="p-3 font-medium cursor-pointer text-left"
           >
             Trend
           </th>
           <th
-            style="padding: 0.75rem; text-align: right; font-weight: 500; cursor: pointer;"
+            class="p-3 font-medium cursor-pointer text-right"
           >
             YTD
           </th>
           <th
-            style="padding: 0.75rem; text-align: right; font-weight: 500; cursor: pointer;"
+            class="p-3 font-medium cursor-pointer text-right"
           >
             1Y
           </th>
           <th
-            style="padding: 0.75rem; text-align: right; font-weight: 500; cursor: pointer;"
+            class="p-3 font-medium cursor-pointer text-right"
           >
             3Y
           </th>
           <th
-            style="padding: 0.75rem; text-align: right; font-weight: 500; cursor: pointer;"
+            class="p-3 font-medium cursor-pointer text-right"
           >
             5Y
           </th>
           <th
-            style="padding: 0.75rem; text-align: right; font-weight: 500; cursor: pointer;"
+            class="p-3 font-medium cursor-pointer text-right"
           >
             Sharpe
           </th>
           <th
-            style="padding: 0.75rem; text-align: right; font-weight: 500; cursor: pointer;"
+            class="p-3 font-medium cursor-pointer text-right"
           >
             Std Dev (5Y)
           </th>
           <th
-            style="padding: 0.75rem; text-align: right; font-weight: 500; cursor: pointer;"
+            class="p-3 font-medium cursor-pointer text-right"
           >
             Expense
           </th>
           <th
-            style="padding: 0.75rem; text-align: left; font-weight: 500; cursor: pointer;"
+            class="p-3 font-medium cursor-pointer text-left"
           >
             Tags
           </th>
@@ -102,75 +102,75 @@ exports[`renders table snapshot 1`] = `
       </thead>
       <tbody>
         <tr
+          class="border-b border-gray-100 cursor-pointer "
           role="button"
-          style="border-bottom: 1px solid #f3f4f6; cursor: pointer; background-color: transparent;"
           tabindex="0"
         >
           <td
-            style="padding: 0.5rem;"
+            class="p-2"
           >
             ABC
           </td>
           <td
-            style="padding: 0.5rem;"
+            class="p-2"
           >
             Alpha Fund
           </td>
           <td
-            style="padding: 0.5rem;"
+            class="p-2"
           />
           <td
-            style="padding: 0.5rem; text-align: center;"
+            class="p-2 text-center"
           >
             <span
-              style="background-color: rgba(22, 163, 74, 0.125); color: rgb(22, 163, 74); border: 1px solid #16a34a50; border-radius: 9999px; font-size: 0.75rem; font-weight: bold; padding: 0.25rem 0.5rem; display: inline-block; min-width: 3rem; text-align: center;"
+              class="inline-block min-w-[3rem] rounded-full border px-2 py-1 text-center text-xs font-bold bg-green-600/20 border-green-600/50 text-green-600"
             >
               75.0 - Strong
             </span>
           </td>
           <td
-            style="padding: 0.5rem; text-align: center;"
+            class="p-2 text-center"
           />
           <td
-            style="padding: 0.5rem;"
+            class="p-2"
           />
           <td
-            style="padding: 0.5rem; text-align: right;"
+            class="p-2 text-right"
           >
             2.00 %
           </td>
           <td
-            style="padding: 0.5rem; text-align: right;"
+            class="p-2 text-right"
           >
             10.00 %
           </td>
           <td
-            style="padding: 0.5rem; text-align: right;"
+            class="p-2 text-right"
           >
             12.00 %
           </td>
           <td
-            style="padding: 0.5rem; text-align: right;"
+            class="p-2 text-right"
           >
             15.00 %
           </td>
           <td
-            style="padding: 0.5rem; text-align: right;"
+            class="p-2 text-right"
           >
             0.80
           </td>
           <td
-            style="padding: 0.5rem; text-align: right;"
+            class="p-2 text-right"
           >
             18.00 %
           </td>
           <td
-            style="padding: 0.5rem; text-align: right;"
+            class="p-2 text-right"
           >
             0.50 %
           </td>
           <td
-            style="padding: 0.5rem;"
+            class="p-2"
           >
             <div
               style="display: flex; flex-wrap: wrap; gap: 0.25rem;"


### PR DESCRIPTION
## What
- replace inline style objects with Tailwind utility classes in table components
- update filter bars to use Tailwind
- refresh affected Jest snapshots

## How to Test
- `npm ci`
- `CI=true npm test -- -u` *(fails: snapshotStore)*
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6863e92b75048329b96b8d8c6e6ec586