### PR TITLE
Refactor FundTable & BenchmarkRow to import ScoreBadge

### DIFF
--- a/src/components/BenchmarkRow.jsx
+++ b/src/components/BenchmarkRow.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { fmtPct, fmtNumber } from '../utils/formatters';
+import ScoreBadge from '@/components/ScoreBadge';
 
 const BenchmarkRow = ({ fund }) => {
   const row = fund;

--- a/src/components/FundTable.jsx
+++ b/src/components/FundTable.jsx
@@ -1,36 +1,13 @@
 import React, { useState, useMemo } from 'react';
 import TagList from './TagList.jsx';
 import BenchmarkRow from './BenchmarkRow.jsx';
-import { getScoreColor, getScoreLabel } from '@/utils/scoreTags';
 import { fmtPct, fmtNumber } from '@/utils/formatters';
 import { LABELS } from '../constants/labels';
-import { getScoreColor, getScoreLabel } from '../services/scoring';
+import ScoreBadge from '@/components/ScoreBadge';
 import SparkLine from './SparkLine';
 import ArrowDropUpIcon from '@mui/icons-material/ArrowDropUp';
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 
-const ScoreBadge = ({ score }) => {
-  const color = getScoreColor(score);
-  const label = getScoreLabel(score);
-  return (
-    <span
-      style={{
-        backgroundColor: `${color}20`,
-        color,
-        border: `1px solid ${color}50`,
-        borderRadius: '9999px',
-        fontSize: '0.75rem',
-        fontWeight: 'bold',
-        padding: '0.25rem 0.5rem',
-        display: 'inline-block',
-        minWidth: '3rem',
-        textAlign: 'center'
-      }}
-    >
-      {Number(score).toFixed(1)} - {label}
-    </span>
-  );
-};
 
 const columns = [
   { key: 'Symbol', label: 'Symbol', numeric: false },


### PR DESCRIPTION
## Summary
- import ScoreBadge component instead of defining it in `FundTable`
- use the same import in `BenchmarkRow`
- drop redundant scoring imports from `FundTable`

## Testing
- `npm test` *(fails: TypeError in parseFundFile and snapshot mismatches)*
- `npm run typecheck`
- `npm run lint:fix` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68640861973083299c194d22dcc04f87