### PR TITLE
Fix benchmark script metrics

### DIFF
--- a/scripts/auditBenchmarks.js
+++ b/scripts/auditBenchmarks.js
@@ -38,9 +38,9 @@ function ensureBenchmarkRows(list = []) {
         oneYear: null,
         threeYear: null,
         fiveYear: null,
-        sharpe: null,
-        stdDev5y: null,
-        expense: null
+        sharpe3Y: null,
+        stdDev5Y: null,
+        expenseRatio: null
       });
     } else {
       const row = map.get(key);


### PR DESCRIPTION
## Summary
- rename placeholder metrics in `auditBenchmarks.js`

## Testing
- `npm test`
- `npm run typecheck`
- `npm run lint:fix` *(fails: 465 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68641faacfc083298468fb23ff9116a8