### PR TITLE
Generic Fund tables

### DIFF
--- a/src/components/FundTable.tsx
+++ b/src/components/FundTable.tsx
@@ -1,12 +1,13 @@
-import React, { useState, useMemo } from 'react';
-import TagList from './TagList.jsx';
-import BenchmarkRow from './BenchmarkRow.jsx';
-import { fmtPct, fmtNumber } from '@/utils/formatters';
-import { LABELS } from '../constants/labels';
-import ScoreBadge from '@/components/ScoreBadge';
-import SparkLine from './SparkLine';
-import ArrowDropUpIcon from '@mui/icons-material/ArrowDropUp';
-import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
+import React, { useState, useMemo } from 'react'
+import TagList from './TagList.jsx'
+import BenchmarkRow from './BenchmarkRow.jsx'
+import { fmtPct, fmtNumber } from '@/utils/formatters'
+import { LABELS } from '../constants/labels'
+import ScoreBadge from '@/components/ScoreBadge'
+import SparkLine from './SparkLine'
+import ArrowDropUpIcon from '@mui/icons-material/ArrowDropUp'
+import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown'
+import type { Fund } from '@/types/fund'
 
 
 const columns = [
@@ -26,7 +27,23 @@ const columns = [
   { key: 'Tags', label: 'Tags', numeric: false, accessor: f => f.tags }
 ];
 
-const FundTable = ({ funds = [], rows, benchmark, onRowClick = () => {}, deltas = {}, spark = {} }) => {
+export interface FundTableProps<T extends Fund = Fund> {
+  funds?: T[]
+  rows?: T[]
+  benchmark?: T
+  onRowClick?: (fund: T) => void
+  deltas?: Record<string, number>
+  spark?: Record<string, number[]>
+}
+
+export default function FundTable<T extends Fund = Fund>({
+  funds = [],
+  rows,
+  benchmark,
+  onRowClick = () => {},
+  deltas = {},
+  spark = {}
+}: FundTableProps<T>) {
   const data = rows || funds;
   const [sort, setSort] = useState({ key: null, dir: 'asc', numeric: false });
 
@@ -153,7 +170,5 @@ const FundTable = ({ funds = [], rows, benchmark, onRowClick = () => {}, deltas 
       </tbody>
     </table>
   </div>
-  );
-};
-
-export default FundTable;
+  )
+}

--- a/src/components/GroupedFundTable.tsx
+++ b/src/components/GroupedFundTable.tsx
@@ -1,29 +1,40 @@
-import React, { useState } from 'react';
-import BenchmarkRow from './BenchmarkRow.jsx';
-import FundTable from './FundTable.jsx';
+import React, { useState } from 'react'
+import BenchmarkRow from './BenchmarkRow.jsx'
+import FundTable from './FundTable'
+import type { Fund } from '@/types/fund'
+
+export interface GroupedFundTableProps<T extends Fund = Fund> {
+  funds?: T[]
+  onRowClick?: (fund: T) => void
+  deltas?: Record<string, number>
+  spark?: Record<string, number[]>
+}
 
 /**
  * Group funds by asset class and render expandable sections.
- * @param {Array<Object>} funds
- * @param {Function} onRowClick
  */
-const GroupedFundTable = ({ funds = [], onRowClick = () => {}, deltas = {}, spark = {} }) => {
-  const groups = {};
+export default function GroupedFundTable<T extends Fund = Fund>({
+  funds = [],
+  onRowClick = () => {},
+  deltas = {},
+  spark = {}
+}: GroupedFundTableProps<T>) {
+  const groups: Record<string, T[]> = {};
   funds.forEach(f => {
     const cls = f.assetClass || 'Uncategorized';
     if (!groups[cls]) groups[cls] = [];
     groups[cls].push(f);
   });
 
-  const [open, setOpen] = useState({});
-  const toggle = cls =>
+  const [open, setOpen] = useState<Record<string, boolean>>({})
+  const toggle = (cls: string) =>
     setOpen(prev => ({ ...prev, [cls]: !prev[cls] }));
 
   return (
     <div>
-      {Object.entries(groups).map(([cls, rows]) => {
-        const benchmark = rows.find(r => r.isBenchmark);
-        const peers = rows.filter(r => !r.isBenchmark);
+      {(Object.entries(groups) as [string, T[]][]).map(([cls, rows]) => {
+        const benchmark = rows.find(r => r.isBenchmark)
+        const peers = rows.filter(r => !r.isBenchmark)
           const avg = peers.length
             ? Math.round(
                 peers.reduce((s, f) => s + ((f.score ?? f.scores?.final) || 0), 0) / peers.length
@@ -51,7 +62,5 @@ const GroupedFundTable = ({ funds = [], onRowClick = () => {}, deltas = {}, spar
         );
       })}
     </div>
-  );
-};
-
-export default GroupedFundTable;
+  )
+}

--- a/src/components/TagList.d.ts
+++ b/src/components/TagList.d.ts
@@ -1,0 +1,5 @@
+import * as React from 'react'
+
+declare const TagList: React.FC<{ tags: string[] }>
+
+export default TagList

--- a/src/components/__tests__/FundTable.interaction.test.jsx
+++ b/src/components/__tests__/FundTable.interaction.test.jsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import FundTable from '../FundTable.jsx';
+import FundTable from '../FundTable';
 
 test('row click calls handler', async () => {
   const fund = {

--- a/src/components/__tests__/FundTable.sort.test.jsx
+++ b/src/components/__tests__/FundTable.sort.test.jsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import FundTable from '../FundTable.jsx';
+import FundTable from '../FundTable';
 
 test('clicking numeric header sorts desc then asc', async () => {
   const data = [

--- a/src/components/__tests__/FundTable.test.jsx
+++ b/src/components/__tests__/FundTable.test.jsx
@@ -1,5 +1,5 @@
 import { render } from '@testing-library/react';
-import FundTable from '../FundTable.jsx';
+import FundTable from '../FundTable';
 
 const sample = [{
   Symbol: 'ABC',

--- a/src/components/__tests__/GroupedFundTable.integration.test.jsx
+++ b/src/components/__tests__/GroupedFundTable.integration.test.jsx
@@ -4,7 +4,7 @@ import * as XLSX from 'xlsx';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
-import GroupedFundTable from '../GroupedFundTable.jsx';
+import GroupedFundTable from '../GroupedFundTable';
 import parseFundFile from '@/utils/parseFundFile';
 import { recommendedFunds, assetClassBenchmarks } from '../../data/config';
 import { calculateScores } from '../../services/scoring';

--- a/src/routes/ClassView.tsx
+++ b/src/routes/ClassView.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react'
-import FundTable from '@/components/FundTable.jsx'
+import FundTable from '@/components/FundTable'
 import { useSnapshot } from '@/contexts/SnapshotContext'
 import type { Fund } from '@/types/fund'
 

--- a/src/routes/FundScores.tsx
+++ b/src/routes/FundScores.tsx
@@ -1,12 +1,12 @@
 import React, { useContext, useMemo, useState, useEffect } from 'react'
 import GlobalFilterBar from '../components/Filters/GlobalFilterBar.jsx'
 import TagFilterBar from '../components/Filters/TagFilterBar.jsx'
-import FundTable from '../components/FundTable.jsx'
-import GroupedFundTable from '../components/GroupedFundTable.jsx'
+import FundTable from '../components/FundTable'
+import GroupedFundTable from '../components/GroupedFundTable'
 import FundDetailsModal from '../components/Modals/FundDetailsModal.jsx'
 import AppContext from '../context/AppContext.jsx'
 import { useSnapshot } from '../contexts/SnapshotContext'
-import { NormalisedRow } from '../utils/parseFundFile'
+import type { Fund } from '../types/fund'
 import UploadDialog from '../components/UploadDialog'
 import UploadIcon from '@mui/icons-material/Upload'
 import { Download } from 'lucide-react'
@@ -18,14 +18,11 @@ import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown'
 import { Box, Button, Typography } from '@mui/material'
 import { savePref, getPref } from '../services/dataStore'
 
-const GroupedTable: React.FC<any> = GroupedFundTable as unknown as React.FC<any>
-const FundTableAny: React.FC<any> = FundTable as unknown as React.FC<any>
-
 
 export default function FundScores () {
   const { active } = useSnapshot()
   console.log('FundScores active snapshot:', active)
-  const rows: NormalisedRow[] = active?.rows ?? []
+  const rows: Fund[] = (active?.rows ?? []) as Fund[]
 
   const [deltas, setDeltas] = React.useState<Record<string, number>>({})
   const [spark, setSpark] = React.useState<Record<string, number[]>>({})
@@ -127,9 +124,9 @@ export default function FundScores () {
       {filteredFunds.length === 0 ? (
         <p style={{ color: '#6b7280' }}>No funds match your current filter selection.</p>
       ) : grouped ? (
-        <GroupedTable funds={filteredFunds as any} onRowClick={setSelectedFund} deltas={deltas} spark={spark} />
+        <GroupedFundTable funds={filteredFunds} onRowClick={setSelectedFund} deltas={deltas} spark={spark} />
       ) : (
-        <FundTableAny funds={filteredFunds as any} onRowClick={setSelectedFund as any} deltas={deltas} spark={spark} />
+        <FundTable funds={filteredFunds} onRowClick={setSelectedFund} deltas={deltas} spark={spark} />
       )}
       {selectedFund && (
         <FundDetailsModal fund={selectedFund} onClose={() => setSelectedFund(null)} />

--- a/src/types/fund.ts
+++ b/src/types/fund.ts
@@ -15,4 +15,5 @@ export interface Fund extends NormalisedRow {
   score?: number
   isRecommended?: boolean
   cleanSymbol?: string
+  Symbol?: string
 }


### PR DESCRIPTION
## Summary
- convert FundTable and GroupedFundTable to TypeScript and add generics
- export Fund `Symbol` in types
- update tests and routes to new component paths
- add typings for TagList

## Testing
- `npm test` *(fails: TypeError: Cannot read properties of undefined)*
- `npm run typecheck`
- `npm run lint:fix` *(fails: 454 problems)*

------
https://chatgpt.com/codex/tasks/task_e_686422b9774c83299675051929542d24