### PR TITLE
Add typed interfaces for analysis modules

### DIFF
--- a/src/routes/AnalysisView.tsx
+++ b/src/routes/AnalysisView.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
 import { Box, Tooltip, Typography } from '@mui/material'
 import { useSnapshot } from '@/contexts/SnapshotContext'
-import db from '@/services/snapshotStore'
+import type { SnapshotRow } from '@/services/snapshotStore'
+import type { SnapshotFund } from '@/types/analysis'
 
 export function bucket (score: number | null) {
   if (score == null) return 'blank'
@@ -19,19 +20,29 @@ const colours: Record<string,string> = {
   blank:'#e0e0e0'
 }
 
+interface HeatmapCell {
+  id: string
+  score: number | null
+}
+
+interface HeatmapRow {
+  symbol: string
+  cells: HeatmapCell[]
+}
+
 export default function AnalysisView () {
   const { list, active } = useSnapshot()
-  const last12 = React.useMemo(
-    () => [...list].sort((a,b)=>a.id.localeCompare(b.id)).slice(-12),
+  const last12 = React.useMemo<SnapshotRow[]>(
+    () => [...list].sort((a, b) => a.id.localeCompare(b.id)).slice(-12),
     [list]
   )
   if (!active) return <Typography p={3}>No snapshot selected.</Typography>
 
   // build matrix
-  const rows = active.rows.map(r => {
-    const cells = last12.map(snap => {
-      const match = snap.rows.find(x => x.symbol === r.symbol)
-      return { id: snap.id, score: (match as any)?.score ?? null }
+  const rows: HeatmapRow[] = active.rows.map((r) => {
+    const cells: HeatmapCell[] = last12.map((snap) => {
+      const match = snap.rows.find(x => x.symbol === r.symbol) as SnapshotFund | undefined
+      return { id: snap.id, score: match?.score ?? null }
     })
     return { symbol: r.symbol, cells }
   })

--- a/src/services/tagRules.ts
+++ b/src/services/tagRules.ts
@@ -1,24 +1,25 @@
-import { ParsedSnapshot } from '@/utils/parseFundFile'
+import type { ParsedSnapshot } from '@/utils/parseFundFile'
+import type { SnapshotFund } from '@/types/analysis'
 
 export function applyTagRules (snapshots: ParsedSnapshot[]): ParsedSnapshot {
   const latest = snapshots[snapshots.length - 1]
   const prev   = snapshots[snapshots.length - 2]
   const prev2  = snapshots[snapshots.length - 3]
 
-  latest.rows.forEach(row => {
-    const history = snapshots
+  latest.rows.forEach((row) => {
+    const curr = row as SnapshotFund
+    const history: SnapshotFund[] = snapshots
       .slice(-6)
-      .map(s => s.rows.find(r => r.symbol === row.symbol))
-      .filter(Boolean) as any[]
+      .map(s => s.rows.find(r => r.symbol === curr.symbol))
+      .filter((r): r is SnapshotFund => Boolean(r))
 
-    const scores = history.map(h => h.score ?? null).filter(n => n != null) as number[]
+    const scores = history.map(h => h.score).filter(n => n != null)
     const tags: string[] = []
 
     // Improving / deteriorating
     if (prev && prev2) {
-      const curr   = row as any
-      const score1 = (prev.rows.find(r => r.symbol === row.symbol) as any)?.score
-      const score2 = (prev2.rows.find(r => r.symbol === row.symbol) as any)?.score
+      const score1 = (prev.rows.find(r => r.symbol === curr.symbol) as SnapshotFund | undefined)?.score
+      const score2 = (prev2.rows.find(r => r.symbol === curr.symbol) as SnapshotFund | undefined)?.score
       if (score1 != null && score2 != null) {
         if (curr.score - score1 >= 5 && score1 - score2 > 0) tags.push('improving')
         if (curr.score - score1 <= -5 && score1 - score2 < 0) tags.push('deteriorating')
@@ -32,7 +33,7 @@ export function applyTagRules (snapshots: ParsedSnapshot[]): ParsedSnapshot {
       if (sd >= 15) tags.push('volatile')
     }
 
-    ;(row as any).tags = tags
+    curr.tags = tags
   })
 
   return latest

--- a/src/services/trendAnalysis.ts
+++ b/src/services/trendAnalysis.ts
@@ -1,22 +1,24 @@
 import db from './snapshotStore'
-import { NormalisedRow } from '@/utils/parseFundFile'
+import type { SnapshotFund, ScoreSeriesEntry } from '@/types/analysis'
 
 /** Return score series (sorted oldest->newest) for given symbol, max N points */
-export async function getScoreSeries (symbol: string, limit = 6):
-  Promise<{ id: string; score: number }[]> {
+export async function getScoreSeries (
+  symbol: string,
+  limit = 6
+): Promise<ScoreSeriesEntry[]> {
 
   const snaps = await db.snapshots.orderBy('id').reverse().limit(limit).toArray()
   return snaps
-    .map(s => {
-      const row = s.rows.find(r => r.symbol === symbol)
-      return row ? { id: s.id, score: (row as any).score ?? 0 } : null
+    .map((s) => {
+      const row = s.rows.find(r => r.symbol === symbol) as SnapshotFund | undefined
+      return row ? { id: s.id, score: row.score ?? 0 } : null
     })
     .filter(Boolean)
-    .reverse() as { id: string; score: number }[]
+    .reverse() as ScoreSeriesEntry[]
 }
 
 /** MoM delta (current \u2013 previous) */
-export function delta (series: { score: number }[]): number | null {
+export function delta (series: Pick<ScoreSeriesEntry, 'score'>[]): number | null {
   if (series.length < 2) return null
   const latest = series[series.length - 1]?.score
   const prev   = series[series.length - 2]?.score

--- a/src/types/analysis.ts
+++ b/src/types/analysis.ts
@@ -1,0 +1,16 @@
+export interface ScoreSeriesEntry {
+  id: string;
+  score: number;
+}
+
+import type { ParsedSnapshot } from '@/utils/parseFundFile';
+import type { Fund } from '@/types/fund';
+
+export interface SnapshotFund extends Fund {
+  score: number;
+  delta?: number;
+}
+
+export interface ScoredSnapshot extends Omit<ParsedSnapshot, 'rows'> {
+  rows: SnapshotFund[];
+}


### PR DESCRIPTION
## What
- introduce `SnapshotFund`, `ScoreSeriesEntry` and related types
- use these types across AnalysisView, trendAnalysis, pdfExport and tagRules
- replace `as any` with typed casts and structures

## How to Test
- `npm test`
- `npm run typecheck`
- `npm run lint:fix`


------
https://chatgpt.com/codex/tasks/task_e_68643c78515c832994c3d549a5cc37ea