### PR TITLE
Refactor scoring helpers for stronger types

### DIFF
--- a/src/routes/FundScores.tsx
+++ b/src/routes/FundScores.tsx
@@ -44,7 +44,7 @@ export default function FundScores () {
     resetFilters
   } = useContext(AppContext)
 
-  const [selectedFund, setSelectedFund] = useState<any>(null)
+  const [selectedFund, setSelectedFund] = useState<Fund | null>(null)
   const [grouped, setGrouped] = useState(false)
 
   const [uploadOpen, setUploadOpen] = useState(false)

--- a/src/services/scoringUtils.ts
+++ b/src/services/scoringUtils.ts
@@ -1,11 +1,15 @@
-import { ParsedSnapshot } from '@/utils/parseFundFile'
+import { ParsedSnapshot, type NormalisedRow } from '@/utils/parseFundFile'
+
+interface ScoredRow extends NormalisedRow {
+  score?: number
+}
 
 const W = { ytd:0.05, one:0.10, three:0.20, five:0.15,
             sharpe:0.25, std:-0.10, exp:-0.10, tenure:0.05 }
 
 /** Add .score to each row using z-scores within its asset class */
-export function attachScores (snap: ParsedSnapshot) {
-  const rows = snap.rows as any[]
+export function attachScores<T extends ParsedSnapshot> (snap: T): T {
+  const rows = snap.rows as ScoredRow[]
   const classes = Array.from(new Set(rows.map(r => r.assetClass)))
   classes.forEach(cls=>{
     const set = rows.filter(r=>r.assetClass===cls)


### PR DESCRIPTION
## Summary
- tighten scoring utils generics
- add typed row parsing with overloads
- type selected fund in scores view

## Testing
- `npm run lint:fix`
- `npm run typecheck`
- `npm test -- -w 1` *(fails: Missing required column: symbol)*

------
https://chatgpt.com/codex/tasks/task_e_686542854ce0832982ec53c19f018a17